### PR TITLE
Movement: make AddLinearSegments segment-queue updates O(1)/O(overlap)

### DIFF
--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -31,6 +31,8 @@ void DriveMovement::Init(size_t drv) noexcept
 	nextDM = nullptr;
 #endif
 	segments = nullptr;
+	segmentsTail = nullptr;
+	segHint = nullptr;
 	segmentFlags.InitNonPrinting();
 #if SUPPORT_CLOSED_LOOP
 	closedLoopControl.InitInstance();
@@ -272,6 +274,8 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		distanceCarriedForwards = newDcf;
 		MoveSegment *oldSeg = seg;
 		segments = seg = seg->GetNext();						// skip this segment
+		if (seg == nullptr) { segmentsTail = nullptr; }			// keep the tail cache consistent when the list empties
+		if (segHint == oldSeg) { segHint = nullptr; }			// invalidate the insertion hint if we are releasing the segment it points to
 		MoveSegment::Release(oldSeg);
 	}
 }
@@ -380,8 +384,11 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 			}
 
 			movementAccumulator += netStepsThisSegment;				// update the amount of extrusion for filament monitors
-			segments = currentSegment->GetNext();
 			const uint32_t prevEndTime = currentSegment->GetStartTime() + currentSegment->GetDuration();
+			MoveSegment *const nextSeg = currentSegment->GetNext();
+			segments = nextSeg;
+			if (nextSeg == nullptr) { segmentsTail = nullptr; }		// keep the tail cache consistent when the list empties
+			if (segHint == currentSegment) { segHint = nullptr; }	// invalidate the insertion hint if we are releasing the segment it points to
 			MoveSegment::Release(currentSegment);
 			currentSegment = NewSegment(now);
 			if (currentSegment == nullptr)
@@ -567,6 +574,8 @@ void DriveMovement::StopDriverFromRemote() noexcept
 		state = DMState::idle;
 		MoveSegment *seg = nullptr;
 		std::swap(seg, const_cast<MoveSegment*&>(segments));
+		segmentsTail = nullptr;
+		segHint = nullptr;
 		MoveSegment::ReleaseAll(seg);
 	}
 }

--- a/src/Movement/DriveMovement.h
+++ b/src/Movement/DriveMovement.h
@@ -86,6 +86,8 @@ private:
 #endif
 
 	MoveSegment *volatile segments;						// pointer to the segment list for this driver
+	MoveSegment *volatile segmentsTail;					// pointer to the last segment in the list, or nullptr if the list is empty; lets us append in O(1)
+	MoveSegment *volatile segHint;						// a segment at or before the next insertion point, or nullptr; lets us start the insertion search near the end instead of at the head
 	ExtruderShaper extruderShaper;						// pressure advance control
 
 	DMState state;										// whether this is active or not
@@ -224,7 +226,10 @@ inline bool DriveMovement::GetCurrentMotion(uint32_t when, MotionParameters& mPa
 				distanceCarriedForwards += seg->GetLength() - (motioncalc_t)netStepsThisSegment;
 				movementAccumulator += netStepsThisSegment;		// update the amount of extrusion
 				MoveSegment *oldSeg = seg;
-				segments = oldSeg->GetNext();
+				MoveSegment *const nextSeg = oldSeg->GetNext();
+				segments = nextSeg;
+				if (nextSeg == nullptr) { segmentsTail = nullptr; }	// keep the tail cache consistent when the list empties
+				if (segHint == oldSeg) { segHint = nullptr; }		// invalidate the insertion hint if we are releasing the segment it points to
 				MoveSegment::Release(oldSeg);
 				seg = NewSegment(when);
 				hasMotion = true;

--- a/src/Movement/Move.cpp
+++ b/src/Movement/Move.cpp
@@ -1038,7 +1038,7 @@ void Move::AddLinearSegments(size_t drive, uint32_t startTime, const PrepParams&
 	// We don't want to disable interrupts during the entire process of adding a segment, because that risks provoking hiccups when we re-enable interrupts and the ISR catches up with the overdue steps.
 	// Instead we break off the tail of the segment chain containing the segments we need to change, re-enable interrupts, then modify that tail as needed. At the end we put the tail back.
 	{
-		MoveSegment *prev = nullptr;
+		MoveSegment *prev;
 
 #if SAMC21 || RP2040
 		const uint32_t oldFlags = IrqSave();
@@ -1046,7 +1046,23 @@ void Move::AddLinearSegments(size_t drive, uint32_t startTime, const PrepParams&
 		const uint32_t oldPrio = ChangeBasePriority(NvicPriorityStep);					// shut out the step interrupt
 #endif
 
-		tail = dm.segments;
+		// Start the search at the cached insertion hint if it is still valid, i.e. it is a segment still in the list that
+		// ends no later than the new segments start. Moves are appended in time order so the insertion point advances
+		// monotonically, making this search O(overlap) instead of O(list length). Otherwise fall back to searching from the head.
+		{
+			MoveSegment * const hint = dm.segHint;
+			if (hint != nullptr && (int32_t)(startTime - (hint->GetStartTime() + hint->GetDuration())) >= 0)
+			{
+				prev = hint;
+				tail = hint->GetNext();
+			}
+			else
+			{
+				prev = nullptr;
+				tail = dm.segments;
+			}
+		}
+
 		while (tail != nullptr)
 		{
 			const uint32_t segStartTime = tail->GetStartTime();
@@ -1097,6 +1113,12 @@ void Move::AddLinearSegments(size_t drive, uint32_t startTime, const PrepParams&
 			prev = tail;
 			tail = tail->GetNext();
 		}
+
+		// After breaking off the tail, dm.segments ends at 'prev' (it is empty if prev is null). Cache 'prev' as the list tail
+		// (used by the O(1) re-join below) and as the hint for the next insertion: its end time is <= startTime and therefore
+		// strictly before the next move's start time, so it is at or before the next insertion point.
+		dm.segHint = prev;
+		dm.segmentsTail = prev;
 
 #if SAMC21 || RP2040
 		IrqRestore(oldFlags);
@@ -1179,6 +1201,17 @@ void Move::AddLinearSegments(size_t drive, uint32_t startTime, const PrepParams&
 	}
 #endif
 
+	// Find the last segment of the constructed tail chain now, while interrupts are still enabled and the step ISR cannot see
+	// this detached chain. This lets us re-join the tail in O(1) inside the interrupt-off window below.
+	MoveSegment *newTail = tail;
+	if (newTail != nullptr)
+	{
+		while (newTail->GetNext() != nullptr)
+		{
+			newTail = newTail->GetNext();
+		}
+	}
+
 	// If there were no segments attached to this DM initially, we need to schedule the interrupt for the new segment at the start of the list.
 	// Don't do this until we have added all the segments for this move, because the first segment we added may have been modified and/or split when we added further segments to implement input shaping
 	{
@@ -1188,21 +1221,19 @@ void Move::AddLinearSegments(size_t drive, uint32_t startTime, const PrepParams&
 		const uint32_t oldPrio = ChangeBasePriority(NvicPriorityStep);					// shut out the step interrupt
 #endif
 
-		// Join the tail back to the end of the segment list
+		// Join the tail back onto the end of the segment list. This is O(1) using the cached tail pointer: dm.segmentsTail is
+		// the last segment of dm.segments (kept consistent by the step ISR, which sets it to null when the list empties).
+		if (tail != nullptr)
 		{
-			MoveSegment *ms = dm.segments;
-			if (ms == nullptr)
+			if (dm.segments == nullptr)
 			{
 				dm.segments = tail;
 			}
 			else
 			{
-				while (ms->GetNext() != nullptr)
-				{
-					ms = ms->GetNext();
-				}
-				ms->SetNext(tail);
+				dm.segmentsTail->SetNext(tail);
 			}
+			dm.segmentsTail = newTail;
 		}
 
 		if (dm.state == DMState::idle)													// if the DM has no segments


### PR DESCRIPTION
On boards without a hardware FPU (SAMC21/RP2040) the step ISR is
dominated by soft-float; under input shaping + pressure advance the step
ISR runtime can exceed MaxStepInterruptTime and provoke hiccups, which
insert movement delay and show up as an extrusion wave on long fast
walls. One contributor is that Move::AddLinearSegments walked the whole
per-drive segment list from the head twice for every move added, inside
or adjacent to the windows in which the step interrupt is shut out.

Cache per-DriveMovement segmentsTail (last segment) and segHint (a
segment at/just before the next insertion point). Window 1 starts its
forward search at segHint instead of the head (O(overlap), bounded by
the shaping span); window 2 re-joins the tail in O(1), with the last
segment of the detached chain located before interrupts are shut out.
The caches are kept consistent / invalidated by the step ISR under the
existing interrupt guard, so they cannot dangle. The resulting segment
list is unchanged.

---
This is one of four independent patches that together eliminate the step-ISR overload (hiccups / extrusion waves under input shaping + pressure advance) observed on TOOL1LC. Each PR stands alone; the four were verified to merge together cleanly and to reproduce the tested combined tree exactly.