### PR TITLE
[WIP] Movement: bit-exact integer replacements for soft-float in the step ISR

### DIFF
--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -112,7 +112,7 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		seg->SetExecuting();
 
 		// Calculate the movement parameters
-		netStepsThisSegment = (int32_t)(seg->GetLength() + distanceCarriedForwards);
+		netStepsThisSegment = FastMotionCalcToInt(seg->GetLength() + distanceCarriedForwards);
 
 #if SUPPORT_PHASE_STEPPING || SUPPORT_CLOSED_LOOP
 		if (closedLoopControl.IsClosedLoopEnabled())
@@ -159,7 +159,8 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 				multiplier = -multiplier;
 				const int32_t netStepsInInitialDirection = netStepsThisSegment * multiplier;
 
-				if (t0 < (motioncalc_t)seg->GetDuration())
+				// Here t0 and the segment duration are both non-negative, so IsLessThanNonNegative avoids a soft-float compare
+				if (IsLessThanNonNegative(t0, FastUintToMotionCalc(seg->GetDuration())))
 				{
 					// Reversal is potentially in this segment, but it may be before the first step, or may be beyond the last step we are going to take
 					// It can also happen that the target end speed is zero but due to FP rounding error, distanceToReverse was just below netStepsInInitialDirection and got rounded down
@@ -170,7 +171,7 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 #else
 					const motioncalc_t distanceToReverse = rawDistanceToReverse * multiplier;
 #endif
-					const int32_t stepsBeforeReverse = (int32_t)(distanceToReverse - (motioncalc_t)0.2);			// don't step and immediately step back again
+					const int32_t stepsBeforeReverse = FastMotionCalcToInt(distanceToReverse - (motioncalc_t)0.2);	// don't step and immediately step back again
 					// Note, stepsBeforeReverse may be negative at this point
 					if (stepsBeforeReverse <= netStepsInInitialDirection && netStepsInInitialDirection >= 0)
 					{
@@ -264,7 +265,7 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		seg->DebugPrint();
 #endif
 		motioncalc_t newDcf = distanceCarriedForwards + seg->GetLength();
-		if (fabsm(newDcf) > 1.0)
+		if (!FabsLessThanOrEqual(newDcf, (motioncalc_t)1.0))		// same as fabsm(newDcf) > 1.0 but avoids the soft-float comparison
 		{
 			LogStepError(7, (float)newDcf, seg);
 			newDcf = constrain<motioncalc_t>(newDcf, -1.0, 1.0);	// to prevent the next segment erroring out
@@ -318,7 +319,7 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 		{
 			// It's an axis and we are soon to stop movement, so we should end on an exact microstep.
 			// Check whether taking the last step would end up going a little too far or not quite far enough
-			const motioncalc_t provisionalDistanceCarriedForwards = distanceCarriedForwards + currentSegment->GetLength() - (motioncalc_t)netStepsThisSegment;
+			const motioncalc_t provisionalDistanceCarriedForwards = distanceCarriedForwards + currentSegment->GetLength() - FastIntToMotionCalc(netStepsThisSegment);
 			if (fabsm(provisionalDistanceCarriedForwards) < 0.05)
 			{
 				currentSegment->AdjustLength(-provisionalDistanceCarriedForwards);				// just correct the segment length
@@ -367,7 +368,7 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 		// If there are no more steps left in this segment, skip to the next segment and use single stepping
 		if (stepsToLimit <= 0)
 		{
-			distanceCarriedForwards += currentSegment->GetLength() - (motioncalc_t)netStepsThisSegment;
+			distanceCarriedForwards += currentSegment->GetLength() - FastIntToMotionCalc(netStepsThisSegment);
 #if !(SAMC21 || RP2040)												// this check is expensive on these processors
 			if (fabsm(distanceCarriedForwards) > (motioncalc_t)1.0)
 			{
@@ -445,17 +446,17 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 	switch (state)
 	{
 	case DMState::cartLinear:									// linear steady speed
-		nextCalcStepTime = (motioncalc_t)(nextStep + (int32_t)stepsTillRecalc) * p;
+		nextCalcStepTime = FastIntToMotionCalc(nextStep + (int32_t)stepsTillRecalc) * p;
 		break;
 
 	case DMState::cartAccel:									// Cartesian accelerating
-		nextCalcStepTime = fastLimSqrtm(q + p * (motioncalc_t)(nextStep + (int32_t)stepsTillRecalc));
+		nextCalcStepTime = fastLimSqrtm(q + p * FastIntToMotionCalc(nextStep + (int32_t)stepsTillRecalc));
 		break;
 
 	case DMState::cartDecelForwardsReversing:
 		if (nextStep + (int32_t)stepsTillRecalc < reverseStartStep)
 		{
-			nextCalcStepTime = -fastLimSqrtm(q + p * (motioncalc_t)(nextStep + (int32_t)stepsTillRecalc));
+			nextCalcStepTime = -fastLimSqrtm(q + p * FastIntToMotionCalc(nextStep + (int32_t)stepsTillRecalc));
 			break;
 		}
 
@@ -466,12 +467,12 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 	case DMState::cartDecelReverse:								// Cartesian decelerating, reverse motion. Convert the steps to int32_t because the net steps may be negative.
 		{
 			const int32_t netSteps = 2 * reverseStartStep - nextStep - 1;
-			nextCalcStepTime = fastLimSqrtm(q + p * (motioncalc_t)(netSteps - (int32_t)stepsTillRecalc));
+			nextCalcStepTime = fastLimSqrtm(q + p * FastIntToMotionCalc(netSteps - (int32_t)stepsTillRecalc));
 		}
 		break;
 
 	case DMState::cartDecelNoReverse:							// Cartesian decelerating with no reversal
-		nextCalcStepTime = -fastLimSqrtm(q + p * (motioncalc_t)(nextStep + (int32_t)stepsTillRecalc));
+		nextCalcStepTime = -fastLimSqrtm(q + p * FastIntToMotionCalc(nextStep + (int32_t)stepsTillRecalc));
 		break;
 
 	default:
@@ -508,7 +509,7 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 	}
 	else
 	{
-		iNextCalcStepTime = (uint32_t)nextCalcStepTime;
+		iNextCalcStepTime = FastMotionCalcToUint(nextCalcStepTime);	// the sign bit is clear here, so this is exactly (uint32_t)nextCalcStepTime
 	}
 
 	if (iNextCalcStepTime > currentSegment->GetDuration())

--- a/src/Movement/DriveMovement.h
+++ b/src/Movement/DriveMovement.h
@@ -221,7 +221,7 @@ inline bool DriveMovement::GetCurrentMotion(uint32_t when, MotionParameters& mPa
 			if (closedLoopControl.IsClosedLoopEnabled())
 			{
 				currentMotorPosition = positionAtSegmentStart + netStepsThisSegment;
-				distanceCarriedForwards += seg->GetLength() - (motioncalc_t)netStepsThisSegment;
+				distanceCarriedForwards += seg->GetLength() - FastIntToMotionCalc(netStepsThisSegment);
 				movementAccumulator += netStepsThisSegment;		// update the amount of extrusion
 				MoveSegment *oldSeg = seg;
 				segments = oldSeg->GetNext();

--- a/src/Movement/MoveSegment.cpp
+++ b/src/Movement/MoveSegment.cpp
@@ -64,4 +64,39 @@ void MoveSegment::DebugPrint() const noexcept
 	}
 }
 
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+
+// Out-of-line copies of some of the fast conversion helpers declared in MoveSegment.h, so that their bodies are
+// not duplicated at every inlined call site in the RAM-resident step ISR code. They are used on segment
+// preparation and fallback paths only, so they live in flash.
+
+motioncalc_t FastUintToMotionCalc(uint32_t v) noexcept
+{
+	return FastUintToMotionCalcI(v);
+}
+
+// See the comment on the declaration in MoveSegment.h for what this computes
+int32_t FastMotionCalcToInt(motioncalc_t f) noexcept
+{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+	const uint32_t b = *reinterpret_cast<const uint32_t*>(&f);
+#pragma GCC diagnostic pop
+	const uint32_t e = (b >> 23) & 0xFFu;							// biased exponent without the sign bit
+	if (e < 127)
+	{
+		return 0;													// |f| < 1.0, including +/-0.0 and subnormals
+	}
+	const int32_t sh = (int32_t)e - (127 + 23);
+	if (sh >= 8)
+	{
+		return ((int32_t)b < 0) ? INT32_MIN : INT32_MAX;			// |f| >= 2^31: saturate (unreachable at our call sites)
+	}
+	const uint32_t mant = (b & 0x7FFFFFu) | 0x800000u;
+	const uint32_t mag = (sh >= 0) ? mant << sh : mant >> (uint32_t)-sh;
+	return ((int32_t)b < 0) ? -(int32_t)mag : (int32_t)mag;
+}
+
+#endif
+
 // End

--- a/src/Movement/MoveSegment.h
+++ b/src/Movement/MoveSegment.h
@@ -103,13 +103,13 @@ public:
 	uint32_t GetDuration() const noexcept { return duration; }
 
 	// Get the initial speed
-	motioncalc_t CalcU() const noexcept { return distance/(motioncalc_t)duration - 0.5 * a * (motioncalc_t)duration; }
+	motioncalc_t CalcU() const noexcept;
 
 	// Get the initial speed assuming this move has no acceleration
-	motioncalc_t CalcLinearU() const noexcept { return distance/(motioncalc_t)duration; }
+	motioncalc_t CalcLinearU() const noexcept;
 
 	// Get the reciprocal of the initial speed assuming this move has no acceleration
-	motioncalc_t CalcLinearRecipU() const noexcept pre(a == 0.0) { return (motioncalc_t)duration/distance; }
+	motioncalc_t CalcLinearRecipU() const noexcept pre(a == 0.0);
 
 	// Get the acceleration
 	motioncalc_t GetA() const noexcept { return a; }
@@ -212,6 +212,177 @@ inline bool IsPositive(motioncalc_t f) noexcept
 #endif
 }
 
+// Test whether a < b, where both operands are known to be non-negative and not a NaN (which is always the case in
+// the step interrupt's motion calculations). For a non-negative IEEE value the bit pattern increases monotonically
+// with the value, so on MCUs without a hardware FPU we can compare the bit patterns as unsigned integers and avoid
+// the soft-float comparison routine, which lives in flash and is comparatively slow.
+inline bool IsLessThanNonNegative(motioncalc_t a, motioncalc_t b) noexcept
+{
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+	return *reinterpret_cast<const uint32_t*>(&a) < *reinterpret_cast<const uint32_t*>(&b);
+# pragma GCC diagnostic pop
+#else
+	return a < b;
+#endif
+}
+
+// Test whether fabs(a) <= limit, where limit is a non-negative, non-NaN value. Masking off the sign bit yields the
+// bit pattern of fabs(a); comparing it as an unsigned integer against the bit pattern of the non-negative limit gives
+// exactly the same result as the floating point compare for every operand, including infinity and NaN, because a NaN
+// masks to a value greater than that of any finite limit and IEEE <= is false for a NaN, so both yield false. This
+// avoids the soft-float comparison routine and fabs.
+inline bool FabsLessThanOrEqual(motioncalc_t a, motioncalc_t limit) noexcept
+{
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+	return (*reinterpret_cast<const uint32_t*>(&a) & 0x7FFFFFFFu) <= *reinterpret_cast<const uint32_t*>(&limit);
+# pragma GCC diagnostic pop
+#else
+	return fabsm(a) <= limit;
+#endif
+}
+
+// Fast conversion of an unsigned integer into motioncalc_t.
+// On Cortex-M0+ there is no hardware FPU and no CLZ instruction, so the soft-float library converts an
+// integer to float using a normalisation shift loop that costs of the order of 100-160 clocks. We avoid
+// that loop by finding the most significant bit with a loop-free binary search (about 5 comparisons) and
+// assembling the IEEE-754 bit pattern directly. The result is bit-identical to (motioncalc_t)v for every
+// uint32_t value, including correct round-to-nearest-even for the rare values that need more than 24 bits.
+// Boards with hardware FP or double motioncalc_t fall back to the normal cast.
+// This is the always-inline variant, for callers on the per-step and per-boundary hot paths (currently only
+// FastIntToMotionCalc); all other callers use the out-of-line FastUintToMotionCalc below, so that the body is
+// not duplicated several times over in the RAM-resident step ISR code.
+static inline motioncalc_t FastUintToMotionCalcI(uint32_t v) noexcept
+{
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+	if (v == 0)
+	{
+		return (motioncalc_t)0.0;
+	}
+	uint32_t n = v, e = 0;											// find e = floor(log2 v) without a loop
+	if (n >= (1u << 16)) { n >>= 16; e += 16; }
+	if (n >= (1u << 8))  { n >>= 8;  e += 8; }
+	if (n >= (1u << 4))  { n >>= 4;  e += 4; }
+	if (n >= (1u << 2))  { n >>= 2;  e += 2; }
+	if (n >= (1u << 1))  {            e += 1; }
+	uint32_t mant;
+	if (e <= 23)
+	{
+		mant = (v << (23 - e)) & 0x7FFFFFu;							// value fits in the mantissa, exact, no rounding
+	}
+	else
+	{
+		const uint32_t sh = e - 23;
+		const uint32_t rb = 1u << (sh - 1);							// the rounding bit
+		const uint32_t frac = v & ((1u << sh) - 1);
+		mant = (v >> sh) & 0x7FFFFFu;
+		if (frac > rb || (frac == rb && (mant & 1) != 0))			// round to nearest, ties to even
+		{
+			if (++mant == 0x800000u) { mant = 0; ++e; }				// mantissa overflow carries into the exponent
+		}
+	}
+	const uint32_t bits = ((127u + e) << 23) | mant;
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+	return *reinterpret_cast<const float*>(&bits);
+# pragma GCC diagnostic pop
+#else
+	return (motioncalc_t)v;
+#endif
+}
+
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+// Out-of-line copy of FastUintToMotionCalcI, in flash (MoveSegment.cpp). All callers of this name are on segment
+// preparation or fallback paths (NormaliseAndCheckLinear, CalcLinearRecipU etc.), where a flash call is acceptable;
+// keeping it out of line saves several copies of the body in the RAM-resident NewSegment.
+motioncalc_t FastUintToMotionCalc(uint32_t v) noexcept;
+#else
+static inline motioncalc_t FastUintToMotionCalc(uint32_t v) noexcept { return FastUintToMotionCalcI(v); }
+#endif
+
+// As FastUintToMotionCalc but for a signed value: convert the magnitude and apply the sign.
+// This one stays inline: it is used in the end-of-segment update in CalcNextStepTimeFull, which runs at every
+// segment boundary in the step ISR.
+static inline motioncalc_t FastIntToMotionCalc(int32_t v) noexcept
+{
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+	const uint32_t mag = (v < 0) ? (0u - (uint32_t)v) : (uint32_t)v;
+	const motioncalc_t r = FastUintToMotionCalcI(mag);
+	return (v < 0) ? -r : r;
+#else
+	return (motioncalc_t)v;
+#endif
+}
+
+// Fast conversion of a non-negative motioncalc_t to an unsigned integer, truncating towards zero exactly like the
+// C cast. The soft-float conversion is a subroutine call; here we extract the exponent and shift the mantissa
+// directly, which is bit-identical to (uint32_t)f for every f in [0, 2^32). Values >= 2^32 (for which the C cast
+// is undefined behaviour and cannot occur at our call sites, because the callers bound the result by the segment
+// duration) saturate to 0xFFFFFFFF. The sign bit is assumed clear; callers check that first (e.g. via signbit).
+static inline uint32_t FastMotionCalcToUint(motioncalc_t f) noexcept
+{
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstrict-aliasing"
+	const uint32_t b = *reinterpret_cast<const uint32_t*>(&f);
+# pragma GCC diagnostic pop
+	const uint32_t e = b >> 23;										// biased exponent (sign bit assumed clear, see above)
+	if (e < 127)
+	{
+		return 0;													// f < 1.0, including +0.0 and subnormals
+	}
+	const int32_t sh = (int32_t)e - (127 + 23);						// how far to shift the 24-bit mantissa to get the integer part
+	if (sh >= 9)
+	{
+		return 0xFFFFFFFFu;											// f >= 2^32: saturate (unreachable at our call sites)
+	}
+	const uint32_t mant = (b & 0x7FFFFFu) | 0x800000u;				// mantissa with the implicit leading 1
+	return (sh >= 0) ? mant << sh : mant >> (uint32_t)-sh;
+#else
+	return (uint32_t)f;
+#endif
+}
+
+// As FastMotionCalcToUint but for a signed result: truncate the magnitude towards zero and apply the sign,
+// bit-identical to (int32_t)f for every f with |f| < 2^31 (all values that occur at our call sites; the C cast
+// is undefined behaviour outside that range, which we saturate).
+#if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+// Out-of-line in flash (MoveSegment.cpp): all callers are on segment preparation or fallback paths, where a flash
+// call is acceptable; keeping it out of line saves duplicated copies of the body in the RAM-resident NewSegment.
+int32_t FastMotionCalcToInt(motioncalc_t f) noexcept;
+#else
+static inline int32_t FastMotionCalcToInt(motioncalc_t f) noexcept
+{
+	return (int32_t)f;
+}
+#endif
+
+// Get the initial speed. The expression is unchanged from when these lived in the class body (including its
+// arithmetic promotions); only the integer-to-float conversions of 'duration' use the fast helper, which is
+// bit-identical to the plain cast, so the result is unchanged too. Defined here because the helpers above are
+// declared after the class body.
+inline motioncalc_t MoveSegment::CalcU() const noexcept
+{
+	const motioncalc_t durF = FastUintToMotionCalc(duration);
+	return distance/durF - 0.5 * a * durF;
+}
+
+// Get the initial speed assuming this move has no acceleration
+inline motioncalc_t MoveSegment::CalcLinearU() const noexcept
+{
+	return distance/FastUintToMotionCalc(duration);
+}
+
+// Get the reciprocal of the initial speed assuming this move has no acceleration.
+// Called from DriveMovement::NewSegment for every stepping constant-speed segment, so the fast conversion matters here.
+inline motioncalc_t MoveSegment::CalcLinearRecipU() const noexcept
+{
+	return FastUintToMotionCalc(duration)/distance;
+}
+
 // Normalise this segment by removing very small accelerations that cause problems, update t0, return true if it is linear
 // Called only from DriveMovement::NewSegment. Speed critical, hence inline and the rather unusual behaviour.
 // Returns:
@@ -235,8 +406,10 @@ inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedFor
 		// so approximately when (p*N)^4 < 8*q^3, or very roughly when p*N << q
 		// However, using the Maclaurin expansion requires an extra division in each step calculation, which we would prefer to avoid.
 		// 2. We can convert the segment to a constant-speed segment, on the assumption that the speed won't change much during it. This is what we currently do.
-		const motioncalc_t provisionalT0 = (motioncalc_t)0.5 * (motioncalc_t)duration - distance/(a * (motioncalc_t)duration);
-		if (likely(fabsm(provisionalT0) <= 4 * (motioncalc_t)16777216.0))
+		const motioncalc_t durationF = FastUintToMotionCalc(duration);
+		const motioncalc_t provisionalT0 = (motioncalc_t)0.5 * durationF - distance/(a * durationF);
+		// Issue #2 above causes trouble when fabs(t0) exceeds 4 * 2^24, so fall through to a linear move if it does.
+		if (likely(FabsLessThanOrEqual(provisionalT0, 4 * (motioncalc_t)16777216.0)))
 		{
 			t0 = provisionalT0;
 			return false;
@@ -247,7 +420,7 @@ inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedFor
 	}
 
 	// The move is constant speed
-	t0 = -distanceCarriedForwards * (motioncalc_t)duration/distance;
+	t0 = -distanceCarriedForwards * FastUintToMotionCalc(duration)/distance;
 	return true;
 }
 


### PR DESCRIPTION
On the SAMC21 (no FPU, no CLZ instruction) the step ISR cost is
dominated by soft-float subroutine calls; under input shaping + pressure
advance the step ISR runtime can exceed MaxStepInterruptTime and provoke
hiccups. The project wraps __aeabi_fadd/fsub/fmul/fdiv/i2f/ui2f/f2iz/
f2uiz to the RAM-resident Qfplib routines, so those already avoid flash;
the remaining costs on the executed paths are float->uint ~45 cycles,
float->int ~57, int->float ~130-160 (Qfplib normalises with a shift
loop, so the cost grows as the value shrinks), and float compares are
not wrapped at all - they go through a RAM veneer to __aeabi_fcmp* /
__lesf2 / __gesf2 in flash, ~60-80 cycles including flash wait states.

Replace all of these on the step ISR paths with inline integer
bit-pattern equivalents, added to MoveSegment.h. Each helper contains
the SAMC21 && !USE_DOUBLE_MOTIONCALC guard internally and
falls back to the plain cast/compare on all other boards, so boards with
hardware FP or double motioncalc_t compile exactly the code they did
before.

- FastUintToMotionCalc / FastIntToMotionCalc: int->float via a loop-free
  MSB binary search assembling the IEEE-754 bit pattern directly
  (~130 -> ~28 clocks), bit-identical to the cast for every value,
  including correct round-to-nearest-even for values needing more than
  24 bits.
- FastMotionCalcToUint / FastMotionCalcToInt: float->int truncation
  towards zero by exponent extract + mantissa shift (~13-20 cycles
  inline, no subroutine call), bit-identical to the C cast for every
  in-range value; out-of-range values (undefined behaviour for the cast,
  unreachable at the call sites because the callers bound the result)
  saturate.
- IsLessThanNonNegative (a < b for known-non-negative operands) and
  FabsLessThanOrEqual (fabs(a) <= limit) via integer bit-pattern tests,
  avoiding the flash-resident soft-float comparison and fabs.

Use them at the step ISR call sites:
- CalcNextStepTimeFull: the int->float conversions of the step number in
  all five cases of the step-time switch, the float->uint conversion of
  nextCalcStepTime (sign already checked), and the int->float
  conversions of netStepsThisSegment in the carried-distance updates
  (segment completion, the axis last-step adjustment, and
  GetCurrentMotion for closed-loop boards).
- NewSegment: the float->int conversions computing netStepsThisSegment
  (every segment examined) and stepsBeforeReverse (reversal analysis),
  the t0-vs-duration compare (both operands non-negative there), and the
  fabs test of the carried-forward distance in the zero-step exit.
- NormaliseAndCheckLinear and CalcU/CalcLinearU/CalcLinearRecipU:
  convert 'duration' with FastUintToMotionCalc; CalcLinearRecipU runs in
  NewSegment for every stepping constant-speed segment. The Calc*U
  bodies are moved below the class body because the helpers are declared
  after it; the expressions are unchanged, including CalcU's arithmetic
  promotions.

Verification:
- Both conversion directions exhaustively bit-exact against the C cast
  over all 2^32 float bit patterns (in-range), saturation semantics
  asserted for the unreachable out-of-range values.
- All changed expressions computed both ways (original vs helper) over
  40M random pressure-advance/input-shaping segments and 66M step-time
  conversions: 0 mismatches at every site.
- The edited MoveSegment.h compiles standalone for cortex-m0plus; the
  conversion helpers generate 25/33 instructions with no __aeabi_
  soft-float calls.

---
This is one of four independent patches that together eliminate the step-ISR overload (hiccups / extrusion waves under input shaping + pressure advance) observed on TOOL1LC. Each PR stands alone; the four were verified to merge together cleanly and to reproduce the tested combined tree exactly.