### PR TITLE
[WIP] Movement: skip coefficient setup for zero-step segments in NewSegment

### DIFF
--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -123,11 +123,33 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		}
 #endif
 
-		bool newDirection;
-		int32_t multiplier;
-		motioncalc_t rawP;
+		bool newDirection = false;					// initialised so the early-skip branch is free of -Wmaybe-uninitialized; overwritten (dead store) in the normal path
+		int32_t multiplier = 0;
+		motioncalc_t rawP = (motioncalc_t)0.0;
 
-		if (seg->NormaliseAndCheckLinear(distanceCarriedForwards, t0))
+		const bool segIsLinear = seg->NormaliseAndCheckLinear(distanceCarriedForwards, t0);
+#if SAMC21 || RP2040
+		// Early zero-step skip (soft-float boards only). A non-reversing segment - linear, or accel/decel whose speed
+		// reversal is not within it (!IsPositive(t0), the same test the full path uses below) - with zero net steps
+		// produces no step pulses. For such a segment the full path below would compute
+		// segmentStepLimit = reverseStartStep = 1 + netStepsThisSegment*multiplier = 1 and state = cartLinear (linear)
+		// or cartAccel (reversal in the past), then take the zero-step exit without emitting a step. We set those three
+		// identically here and skip only the expensive coefficient work (the soft-float divisions that compute rawP and q).
+		// q and p are deliberately left unchanged: computing them needs the soft-float division this skip exists to
+		// avoid. The only consumer that affects motion is the CalcNextStepTimeFull switch, which is reached solely for a
+		// segment that emits a step; this segment emits none and is released without becoming the current segment, and
+		// every stepping segment recomputes q and p (full path) before that switch reads them. (DriveMovement::DebugPrint
+		// also reads q/p, but only as diagnostic output for a non-idle DM.) Reversing segments (IsPositive(t0)) are left
+		// to the full path, which may emit forward+back pulses at zero net steps.
+		if (netStepsThisSegment == 0 && (segIsLinear || !IsPositive(t0)))
+		{
+			reverseStartStep = segmentStepLimit = 1;
+			state = (segIsLinear) ? DMState::cartLinear : DMState::cartAccel;
+		}
+		else
+		{	// brace closed (under the same guard) just before the step-count check below; block left un-re-indented to keep the diff small
+#endif
+		if (segIsLinear)
 		{
 			// Segment is linear
 			rawP = seg->CalcLinearRecipU();
@@ -215,6 +237,10 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		p = (newDirection) ? rawP : -rawP;
 #else
 		p = rawP * multiplier;
+#endif
+
+#if SAMC21 || RP2040
+		}	// end of the non-early-skip block opened after NormaliseAndCheckLinear above
 #endif
 
 		nextStep = 1;


### PR DESCRIPTION
On SAMC21/RP2040 (no FPU, soft-float) the input shaper emits many
sub-step segments, and NewSegment ran the full coefficient setup
(NormaliseAndCheckLinear + two soft-float divisions + reversal analysis)
for each of them, before the step-count check released the segment
without emitting a step. Under input shaping + pressure advance this
contributes to step ISR runtimes that exceed MaxStepInterruptTime and
provoke hiccups, which insert movement delay and show up as an extrusion
wave on long fast walls.

For a non-reversing segment - linear, or accel/decel whose speed
reversal is not within it (!IsPositive(t0), the same test the full path
uses) - with zero net steps, the full path would compute
segmentStepLimit = reverseStartStep = 1 + netStepsThisSegment*multiplier
= 1 and state = cartLinear (linear) / cartAccel (reversal in the past),
i.e. no pulse. Detect that early and set those three members
identically, skipping only the expensive coefficient work (the
soft-float divisions that compute rawP and q). q and p are deliberately
left unchanged: the only consumer that affects motion is the
CalcNextStepTimeFull switch, reached solely for a segment that emits a
step; a skipped segment emits none and is released without becoming the
current segment, and every stepping segment recomputes q and p before
that switch reads them (DebugPrint also reads them, but only
diagnostically). Reversing segments (IsPositive(t0)) are left to the
full path, since they can emit forward+back pulses at zero net steps
(e.g. under pressure advance).

Verified off-target against the full step-count logic: reversal pulses
are never skipped, the carried-forward distance is bit-identical, and
the DM state returned by NewSegment (state / reverseStartStep /
segmentStepLimit) matches the full path on every termination, including
the starting/idle cases where the skip leaves q/p stale.

SAMC21/RP2040 only; no change on other boards.

---
This is one of four independent patches that together eliminate the step-ISR overload (hiccups / extrusion waves under input shaping + pressure advance) observed on TOOL1LC. Each PR stands alone; the four were verified to merge together cleanly and to reproduce the tested combined tree exactly.