### PR TITLE
Movement: prepare upcoming segment parameters outside the step ISR (SAMC21)

### DIFF
--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -17,6 +17,13 @@
 
 int32_t DriveMovement::maxStepsLate = 0;
 
+#if SHADOW_CACHE_DIAGNOSTICS
+uint32_t DriveMovement::shadowCacheHits = 0;
+uint32_t DriveMovement::shadowCacheMisses = 0;
+uint32_t DriveMovement::maxCacheSkip = 0;
+uint32_t DriveMovement::maxIsrSkip = 0;
+#endif
+
 void DriveMovement::Init(size_t drv) noexcept
 {
 	drive = (uint8_t)drv;
@@ -417,6 +424,9 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 {
 	positionAtSegmentStart = currentMotorPosition;
 
+#if SHADOW_CACHE_DIAGNOSTICS
+	unsigned int skipRun = 0;								// diagnostic: the number of zero-step segments this call has skipped without a prepared slot
+#endif
 	while (true)
 	{
 		MoveSegment *seg = segments;				// capture volatile variable
@@ -449,6 +459,10 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 					// A run of zero-step segments precedes the prepared stepping segment. Release them all without any per-segment
 					// float maths: the preparation computed the resulting distanceCarriedForwards bit-identically and verified its error bound.
 					unsigned int n = slot.numSlivers;
+#if SHADOW_CACHE_DIAGNOSTICS
+					if (n > maxCacheSkip) { maxCacheSkip = n; }
+					shadowCacheHits += n;						// each sliver released from the slot counts as a hit
+#endif
 					do
 					{
 						MoveSegment *const oldSeg = seg;
@@ -490,6 +504,9 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 				slot.seg = nullptr;								// consume the slot; Move::Spin on the MAIN task refills it
 				shadowHead = (shadowHead + 1u == NumShadowSlots) ? 0 : shadowHead + 1u;	// no % here: modulo by 3 would call the division function in flash
 				++shadowGen;
+#if SHADOW_CACHE_DIAGNOSTICS
+				++shadowCacheHits;
+#endif
 
 				// Update variables used by filament monitoring, as the normal path below does
 				if (segmentFlags.isExtruder)
@@ -543,6 +560,10 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 			// Re-enable all drivers for this axis
 			driversCurrentlyUsed = driversNormallyUsed;
 
+#if SHADOW_CACHE_DIAGNOSTICS
+			++shadowCacheMisses;						// this stepping segment was not served from a prepared slot
+#endif
+
 			// Update variables used by filament monitoring
 			if (segmentFlags.isExtruder)
 			{
@@ -590,6 +611,11 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		{
 			FlushShadows();										// we are releasing a segment the preparation covers without consuming it, so the slots are stale
 		}
+#if SHADOW_CACHE_DIAGNOSTICS
+		++shadowCacheMisses;									// this zero-step segment was skipped without a prepared slot
+		++skipRun;
+		if (skipRun > maxIsrSkip) { maxIsrSkip = skipRun; }
+#endif
 #endif
 		MoveSegment *oldSeg = seg;
 		segments = seg = seg->GetNext();						// skip this segment

--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -34,6 +34,11 @@ void DriveMovement::Init(size_t drv) noexcept
 	segmentsTail = nullptr;
 	segHint = nullptr;
 	segmentFlags.InitNonPrinting();
+#if USE_SHADOW_SEGMENTS
+	shadowHead = 0;
+	shadowGen = 0;
+	FlushShadows();
+#endif
 #if SUPPORT_CLOSED_LOOP
 	closedLoopControl.InitInstance();
 #endif
@@ -89,9 +94,10 @@ struct SegAnalysis
 };
 
 // Analyse one segment: calculate the p and q coefficients (t = t0 + sqrt(p*n + q) for accelerating or decelerating
-// segments), the step limits and the initial direction and state. Factored out of NewSegment, keeping exactly the
-// expressions it contained there, so that other code can compute bit-identical results from a copy of the segment fields.
-// segIsLinear and t0 are the results of MoveSegment::NormaliseAndCheckLinear on the same values.
+// segments), the step limits and the initial direction and state. This is the single copy of the analysis code, shared
+// between NewSegment and PrepareShadowChunk (which works on a copy of the segment fields), so that both compute
+// bit-identical results from the same inputs.
+// segIsLinear and t0 are the results of MoveSegment::NormaliseAndCheckLinear/CheckLinearCore on the same values.
 static inline void AnalyseSegment(bool segIsLinear, motioncalc_t t0, int32_t netSteps, motioncalc_t length, motioncalc_t a, uint32_t duration, motioncalc_t distanceCarriedForwards, SegAnalysis& out) noexcept
 {
 	bool newDirection;
@@ -190,6 +196,213 @@ static inline void AnalyseSegment(bool segIsLinear, motioncalc_t t0, int32_t net
 	out.direction = newDirection;
 }
 
+#if USE_SHADOW_SEGMENTS
+
+// Prepare the movement parameters of one more upcoming stepping segment (and any run of zero-step segments preceding
+// it) into a free shadow slot, taking the coefficient float maths for that segment boundary out of the step ISR.
+// The preparation is possible because the distanceCarriedForwards each upcoming segment starts with is fully determined
+// in advance: it changes only at segment boundaries, by dcf += length - netSteps with netSteps = int(length + dcf), so
+// the whole chain follows from the executing segment's values (which cannot change while it has a successor). The chain
+// below uses exactly the operations of the corresponding updates in NewSegment and CalcNextStepTimeFull, and the
+// analysis is the same single copy of code that NewSegment uses (AnalyseSegment/CheckLinearCore), so all stored values
+// are bit-identical to what the normal path would compute.
+// This runs with interrupts enabled while the step ISR may release segments, so each segment is copied under a brief
+// interrupt-disabled window, and the result is committed only if shadowGen is unchanged, i.e. no segment was released,
+// no slot consumed or flushed, and no list modification made meanwhile. Correctness never depends on the preparation:
+// any list change invalidates the affected slots and the boundary then falls back to the normal path.
+__attribute__((noinline)) bool DriveMovement::PrepareShadowChunk() noexcept
+{
+	// Values captured about a segment with interrupts disabled, so that the float maths can run on a consistent copy
+	struct SegSnapshot
+	{
+		uint32_t startTime;
+		uint32_t duration;
+		motioncalc_t distance;
+		motioncalc_t a;
+		const MoveSegment *next;
+	};
+
+	const MoveSegment *cursor;								// the first segment of the run we will prepare
+	motioncalc_t dcf = (motioncalc_t)0.0;					// distanceCarriedForwards at the start of *cursor
+	unsigned int slotIdx;
+	uint32_t gen0;
+	bool anchorIsExecutingHead = false;
+	motioncalc_t anchorLen = (motioncalc_t)0.0;
+	motioncalc_t anchorDcf = (motioncalc_t)0.0;
+	int32_t anchorNetSteps = 0;
+
+#if SUPPORT_PHASE_STEPPING || SUPPORT_CLOSED_LOOP
+	if (closedLoopControl.IsClosedLoopEnabled())
+	{
+		return false;										// segments are not executed step-by-step in closed loop mode, and NewSegment takes the phase stepping exit before the slot check
+	}
+#endif
+
+	{
+		const uint32_t oldFlags = IrqSave();
+		gen0 = shadowGen;
+
+		// Find the first free slot in ring order; the last valid slot (if any) anchors the dcf chain
+		const ShadowSlot *lastValid = nullptr;
+		unsigned int k;
+		for (k = 0; k < NumShadowSlots; ++k)
+		{
+			const ShadowSlot& s = shadowSlots[(shadowHead + k) % NumShadowSlots];
+			if (s.seg == nullptr)
+			{
+				break;
+			}
+			lastValid = &s;
+		}
+		if (k == NumShadowSlots)
+		{
+			IrqRestore(oldFlags);
+			return false;									// all slots are already prepared
+		}
+		slotIdx = (shadowHead + k) % NumShadowSlots;
+
+		if (lastValid != nullptr)
+		{
+			cursor = lastValid->seg->GetNext();				// safe: a segment covered by a valid slot has not been released
+			dcf = lastValid->dcfAfterSeg;
+		}
+		else
+		{
+			MoveSegment *const head = segments;
+			if (head == nullptr)
+			{
+				IrqRestore(oldFlags);
+				return false;
+			}
+			if (head->GetFlags().executing)
+			{
+				// The executing head's dcf update is float maths, so capture the inputs and do the arithmetic with interrupts re-enabled
+				anchorIsExecutingHead = true;
+				anchorDcf = distanceCarriedForwards;
+				anchorLen = head->GetLength();
+				anchorNetSteps = netStepsThisSegment;
+				cursor = head->GetNext();
+			}
+			else
+			{
+				cursor = head;								// the head segment has not started executing yet (DM idle or starting)
+				dcf = distanceCarriedForwards;
+			}
+		}
+		IrqRestore(oldFlags);
+	}
+
+	if (cursor == nullptr)
+	{
+		return false;
+	}
+	if (anchorIsExecutingHead)
+	{
+		dcf = anchorDcf + (anchorLen - (motioncalc_t)anchorNetSteps);	// exactly the end-of-segment update in CalcNextStepTimeFull
+	}
+
+	ShadowSlot local;
+	local.chainHead = cursor;
+	unsigned int numSlivers = 0;
+	uint32_t prevEndTime = 0;								// only used once numSlivers != 0
+	for (;;)
+	{
+		SegSnapshot snap;
+		{
+			const uint32_t oldFlags = IrqSave();
+			snap.startTime = cursor->GetStartTime();
+			snap.duration = cursor->GetDuration();
+			snap.distance = cursor->GetLength();
+			snap.a = cursor->GetA();
+			snap.next = cursor->GetNext();
+			IrqRestore(oldFlags);
+		}
+
+		if (numSlivers != 0 && snap.startTime != prevEndTime)
+		{
+			return false;									// a gap after a sliver: the normal path waits for the start time then, so don't span it
+		}
+
+		const int32_t netSteps = (int32_t)(snap.distance + dcf);	// exactly the netStepsThisSegment calculation in NewSegment
+
+		motioncalc_t sT0;
+		const bool segIsLinear = (CheckLinearCore(snap.a, snap.duration, snap.distance, dcf, sT0) != 0);
+		SegAnalysis an;
+		AnalyseSegment(segIsLinear, sT0, netSteps, snap.distance, snap.a, snap.duration, dcf, an);
+
+		if (an.stepLimit <= 1)
+		{
+			// A zero-step segment: fold it into the run as a sliver
+			const motioncalc_t newDcf = dcf + snap.distance;	// exactly the update the skip path in NewSegment makes
+			if (fabsm(newDcf) > 1.0)
+			{
+				return false;								// this would be a step error; leave it to the normal path to detect and report
+			}
+			dcf = newDcf;
+			if (snap.next == nullptr || numSlivers >= 250)
+			{
+				return false;								// no stepping segment follows (yet); leave the run to the normal path
+			}
+			++numSlivers;
+			prevEndTime = snap.startTime + snap.duration;
+			cursor = snap.next;
+			continue;
+		}
+
+		// A stepping segment: complete the slot
+		local.seg = cursor;
+		local.t0 = sT0;
+		local.p = an.p;
+		local.q = an.q;
+		local.numSlivers = (uint8_t)numSlivers;
+		local.state = an.state;
+		local.direction = an.direction;
+		local.netSteps = netSteps;
+		local.stepLimit = an.stepLimit;
+		local.reverseStartStep = an.reverseStartStep;
+		local.dcfAtSeg = dcf;
+		local.dcfAfterSeg = dcf + (snap.distance - (motioncalc_t)netSteps);	// exactly the end-of-segment update in CalcNextStepTimeFull
+		break;
+	}
+
+	// Commit the slot, unless the ISR released segments or consumed/flushed slots while we were computing
+	bool committed = false;
+	{
+		const uint32_t oldFlags = IrqSave();
+		ShadowSlot& s = shadowSlots[slotIdx];
+		if (shadowGen == gen0 && s.seg == nullptr)
+		{
+			s = local;										// interrupts are off, so the ISR cannot see a partially-written slot
+			committed = true;
+		}
+		IrqRestore(oldFlags);
+	}
+	return committed;
+}
+
+// Flush all prepared slots unless every one of them covers only segments that end at or before startTime, which
+// segments added from startTime onwards cannot affect. Caller must have the step interrupt shut out.
+// shadowGen is bumped unconditionally so that a preparation in flight that walked segments the caller is about to modify discards at commit.
+void DriveMovement::InvalidateShadowsFrom(uint32_t startTime) noexcept
+{
+	++shadowGen;
+	for (unsigned int k = 0; k < NumShadowSlots; ++k)
+	{
+		const ShadowSlot& s = shadowSlots[(shadowHead + k) % NumShadowSlots];
+		if (s.seg == nullptr)
+		{
+			break;
+		}
+		if ((int32_t)(startTime - (s.seg->GetStartTime() + s.seg->GetDuration())) < 0)
+		{
+			FlushShadows();
+			break;
+		}
+	}
+}
+
+#endif	// USE_SHADOW_SEGMENTS
+
 // This is called when we need to examine the segment list and prepare the head segment (if there is one) for execution.
 // If there is no segment to execute, set our state to 'idle' and return nullptr.
 // If there is a segment to execute but it isn't due to start for a while, set our state to 'starting', set nextStepTime to when the move is due to start or shortly before,
@@ -225,6 +438,76 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		}
 
 		seg->SetExecuting();
+
+#if USE_SHADOW_SEGMENTS
+		{
+			ShadowSlot& slot = shadowSlots[shadowHead];
+			if (slot.seg != nullptr && seg == slot.chainHead)
+			{
+				if (slot.numSlivers != 0)
+				{
+					// A run of zero-step segments precedes the prepared stepping segment. Release them all without any per-segment
+					// float maths: the preparation computed the resulting distanceCarriedForwards bit-identically and verified its error bound.
+					unsigned int n = slot.numSlivers;
+					do
+					{
+						MoveSegment *const oldSeg = seg;
+						segments = seg = seg->GetNext();
+						if (segHint == oldSeg) { segHint = nullptr; }	// (a stepping segment always follows the slivers, so the list cannot empty here)
+						++shadowGen;
+						MoveSegment::Release(oldSeg);
+						--n;
+					} while (n != 0 && seg != nullptr);
+					distanceCarriedForwards = slot.dcfAtSeg;
+					if (seg == slot.seg)
+					{
+						slot.chainHead = seg;					// the slivers are done with; next time round the loop the prepared parameters apply
+						slot.numSlivers = 0;
+					}
+					else
+					{
+						FlushShadows();							// the list is not what the preparation saw; fall back to the normal path
+					}
+					continue;									// go round the loop again so that the start time check runs for the next segment
+				}
+
+				// seg is the prepared stepping segment: apply the prepared parameters instead of doing the float maths below;
+				// distanceCarriedForwards already has exactly the value the preparation used
+				netStepsThisSegment = slot.netSteps;
+				segmentStepLimit = slot.stepLimit;
+				reverseStartStep = slot.reverseStartStep;
+				state = slot.state;
+				t0 = slot.t0;
+				p = slot.p;
+				q = slot.q;
+				nextStep = 1;
+				if (slot.direction != direction)
+				{
+					directionChanged = true;
+					direction = slot.direction;
+				}
+				driversCurrentlyUsed = driversNormallyUsed;		// re-enable all drivers for this axis
+				slot.seg = nullptr;								// consume the slot; Move::Spin on the MAIN task refills it
+				shadowHead = (shadowHead + 1u == NumShadowSlots) ? 0 : shadowHead + 1u;	// no % here: modulo by 3 would call the division function in flash
+				++shadowGen;
+
+				// Update variables used by filament monitoring, as the normal path below does
+				if (segmentFlags.isExtruder)
+				{
+					if (segmentFlags.nonPrintingMove)
+					{
+						extruderPrinting = false;
+					}
+					else if (!extruderPrinting)
+					{
+						extruderPrintingSince = millis();
+						extruderPrinting = true;
+					}
+				}
+				return seg;
+			}
+		}
+#endif
 
 		// Calculate the movement parameters
 		netStepsThisSegment = (int32_t)(seg->GetLength() + distanceCarriedForwards);
@@ -301,6 +584,13 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 			newDcf = constrain<motioncalc_t>(newDcf, -1.0, 1.0);	// to prevent the next segment erroring out
 		}
 		distanceCarriedForwards = newDcf;
+#if USE_SHADOW_SEGMENTS
+		++shadowGen;											// tell PrepareShadowChunk that a segment has been released
+		if (shadowSlots[shadowHead].seg != nullptr && (seg == shadowSlots[shadowHead].chainHead || seg == shadowSlots[shadowHead].seg))
+		{
+			FlushShadows();										// we are releasing a segment the preparation covers without consuming it, so the slots are stale
+		}
+#endif
 		MoveSegment *oldSeg = seg;
 		segments = seg = seg->GetNext();						// skip this segment
 		if (seg == nullptr) { segmentsTail = nullptr; }			// keep the tail cache consistent when the list empties
@@ -412,6 +702,13 @@ pre(stepsTillRecalc == 0; segments != nullptr)
 				return LogStepError(6, 0.0, currentSegment);
 			}
 
+#if USE_SHADOW_SEGMENTS
+			++shadowGen;										// tell PrepareShadowChunk that a segment has been released
+			if (shadowSlots[shadowHead].seg != nullptr && (currentSegment == shadowSlots[shadowHead].chainHead || currentSegment == shadowSlots[shadowHead].seg))
+			{
+				FlushShadows();									// can't happen (a prepared segment is consumed when it starts executing), but don't risk stale slots
+			}
+#endif
 			movementAccumulator += netStepsThisSegment;				// update the amount of extrusion for filament monitors
 			const uint32_t prevEndTime = currentSegment->GetStartTime() + currentSegment->GetDuration();
 			MoveSegment *const nextSeg = currentSegment->GetNext();
@@ -601,6 +898,9 @@ void DriveMovement::StopDriverFromRemote() noexcept
 	if (state != DMState::idle)
 	{
 		state = DMState::idle;
+#if USE_SHADOW_SEGMENTS
+		FlushShadows();										// the prepared slots refer to segments we are about to release
+#endif
 		MoveSegment *seg = nullptr;
 		std::swap(seg, const_cast<MoveSegment*&>(segments));
 		segmentsTail = nullptr;

--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -77,6 +77,119 @@ bool DriveMovement::ScheduleFirstSegment() noexcept
 	return false;
 }
 
+// The result of analysing one segment against the distance carried forwards that it will start with
+struct SegAnalysis
+{
+	bool direction;										// the initial movement direction
+	DMState state;										// the initial DM state
+	int32_t stepLimit;									// the value for segmentStepLimit
+	int32_t reverseStartStep;							// the value for reverseStartStep
+	motioncalc_t p;										// the p coefficient, with the direction sign applied
+	motioncalc_t q;										// the q coefficient (0.0 for linear segments, to make the debug output consistent)
+};
+
+// Analyse one segment: calculate the p and q coefficients (t = t0 + sqrt(p*n + q) for accelerating or decelerating
+// segments), the step limits and the initial direction and state. Factored out of NewSegment, keeping exactly the
+// expressions it contained there, so that other code can compute bit-identical results from a copy of the segment fields.
+// segIsLinear and t0 are the results of MoveSegment::NormaliseAndCheckLinear on the same values.
+static inline void AnalyseSegment(bool segIsLinear, motioncalc_t t0, int32_t netSteps, motioncalc_t length, motioncalc_t a, uint32_t duration, motioncalc_t distanceCarriedForwards, SegAnalysis& out) noexcept
+{
+	bool newDirection;
+	int32_t multiplier;
+	motioncalc_t rawP;
+
+	if (segIsLinear)
+	{
+		// Segment is linear
+		rawP = (motioncalc_t)duration/length;					// as MoveSegment::CalcLinearRecipU
+		newDirection = !std::signbit(length);
+		multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
+		out.reverseStartStep = out.stepLimit = 1 + netSteps * multiplier;
+		out.q = (motioncalc_t)0.0;								// to make the debug output consistent
+		out.state = DMState::cartLinear;
+	}
+	else
+	{
+		// Segment has acceleration or deceleration
+		// n = distanceCarriedForwards + u * t + 0.5 * a * t^2
+		// Therefore 0.5 * t^2 + u * t/a + (distanceCarriedForwards - n)/a = 0
+		// Therefore t = -u/a +/- sqrt((u/a)^2 - 2 * (distanceCarriedForwards - n)/a)
+		// Calculate the t0, p and q coefficients for an accelerating or decelerating move such that t = t0 + sqrt(p*n + q) and set up the initial direction
+		newDirection = !std::signbit(a);			// assume accelerating motion
+		multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
+		if (!IsPositive(t0))								// use IsPositive here, on Cortex-M0+ it's faster than a floating point compare
+		{
+			// The direction reversal is in the past so the initial direction is the direction of the acceleration
+			out.stepLimit = out.reverseStartStep = 1 + netSteps * multiplier;
+			out.state = DMState::cartAccel;
+		}
+		else
+		{
+			// The initial direction is opposite to the acceleration
+			newDirection = !newDirection;
+			multiplier = -multiplier;
+			const int32_t netStepsInInitialDirection = netSteps * multiplier;
+
+			if (t0 < (motioncalc_t)duration)
+			{
+				// Reversal is potentially in this segment, but it may be before the first step, or may be beyond the last step we are going to take
+				// It can also happen that the target end speed is zero but due to FP rounding error, distanceToReverse was just below netStepsInInitialDirection and got rounded down
+				// Note, t0 = -u/a therefore u = a*t0 therefore u*t0^2 + 0.5*a*t0^2 = -a*t0^2 + 0.5*a*t0^2 = -0.5*a*t0^2
+				const motioncalc_t rawDistanceToReverse = (motioncalc_t)-0.5 * a * msquare(t0) + distanceCarriedForwards;
+#if SAMC21 || RP2040							// avoid floating point multiplication
+				const motioncalc_t distanceToReverse = (newDirection) ? rawDistanceToReverse : -rawDistanceToReverse;
+#else
+				const motioncalc_t distanceToReverse = rawDistanceToReverse * multiplier;
+#endif
+				const int32_t stepsBeforeReverse = (int32_t)(distanceToReverse - (motioncalc_t)0.2);			// don't step and immediately step back again
+				// Note, stepsBeforeReverse may be negative at this point
+				if (stepsBeforeReverse <= netStepsInInitialDirection && netStepsInInitialDirection >= 0)
+				{
+					out.stepLimit = out.reverseStartStep = netStepsInInitialDirection + 1;
+					out.state = DMState::cartDecelNoReverse;
+				}
+				else if (stepsBeforeReverse <= 0)
+				{
+					// Reversal happens immediately
+					newDirection = !newDirection;
+#if !(SAMC21 || RP2040)															// we've finished with 'multiplier' on these processors
+					multiplier = -multiplier;
+#endif
+					out.stepLimit = out.reverseStartStep = 1 - netStepsInInitialDirection;
+					out.state = DMState::cartAccel;
+				}
+				else
+				{
+					out.reverseStartStep = stepsBeforeReverse + 1;
+					out.stepLimit = 2 * out.reverseStartStep - netStepsInInitialDirection - 1;
+					out.state = DMState::cartDecelForwardsReversing;
+				}
+			}
+			else
+			{
+				// Reversal doesn't occur until after the end of this segment
+				out.stepLimit = out.reverseStartStep = netStepsInInitialDirection + 1;
+				out.state = DMState::cartDecelNoReverse;
+			}
+		}
+		rawP = (motioncalc_t)2.0/a;
+		out.q = msquare(t0) - rawP * distanceCarriedForwards;
+#if 0
+		if (std::isinf(out.q))
+		{
+			debugPrintf("t0=%.1f mult=%.1f dcf=%.3e a=%.4e\n", (double)t0, (double)multiplier, (double)distanceCarriedForwards, (double)a);
+		}
+#endif
+	}
+
+#if SAMC21 || RP2040							// avoid floating point multiplication
+	out.p = (newDirection) ? rawP : -rawP;
+#else
+	out.p = rawP * multiplier;
+#endif
+	out.direction = newDirection;
+}
+
 // This is called when we need to examine the segment list and prepare the head segment (if there is one) for execution.
 // If there is no segment to execute, set our state to 'idle' and return nullptr.
 // If there is a segment to execute but it isn't due to start for a while, set our state to 'starting', set nextStepTime to when the move is due to start or shortly before,
@@ -125,99 +238,15 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		}
 #endif
 
-		bool newDirection;
-		int32_t multiplier;
-		motioncalc_t rawP;
-
-		if (seg->NormaliseAndCheckLinear(distanceCarriedForwards, t0))
-		{
-			// Segment is linear
-			rawP = seg->CalcLinearRecipU();
-			newDirection = !std::signbit(seg->GetLength());
-			multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
-			reverseStartStep = segmentStepLimit = 1 + netStepsThisSegment * multiplier;
-			q = (motioncalc_t)0.0;								// to make the debug output consistent
-			state = DMState::cartLinear;
-		}
-		else
-		{
-			// Segment has acceleration or deceleration
-			// n = distanceCarriedForwards + u * t + 0.5 * a * t^2
-			// Therefore 0.5 * t^2 + u * t/a + (distanceCarriedForwards - n)/a = 0
-			// Therefore t = -u/a +/- sqrt((u/a)^2 - 2 * (distanceCarriedForwards - n)/a)
-			// Calculate the t0, p and q coefficients for an accelerating or decelerating move such that t = t0 + sqrt(p*n + q) and set up the initial direction
-			newDirection = !std::signbit(seg->GetA());			// assume accelerating motion
-			multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
-			if (!IsPositive(t0))								// use IsPositive here, on Cortex-M0+ it's faster than a floating point compare
-			{
-				// The direction reversal is in the past so the initial direction is the direction of the acceleration
-				segmentStepLimit = reverseStartStep = 1 + netStepsThisSegment * multiplier;
-				state = DMState::cartAccel;
-			}
-			else
-			{
-				// The initial direction is opposite to the acceleration
-				newDirection = !newDirection;
-				multiplier = -multiplier;
-				const int32_t netStepsInInitialDirection = netStepsThisSegment * multiplier;
-
-				if (t0 < (motioncalc_t)seg->GetDuration())
-				{
-					// Reversal is potentially in this segment, but it may be before the first step, or may be beyond the last step we are going to take
-					// It can also happen that the target end speed is zero but due to FP rounding error, distanceToReverse was just below netStepsInInitialDirection and got rounded down
-					// Note, t0 = -u/a therefore u = a*t0 therefore u*t0^2 + 0.5*a*t0^2 = -a*t0^2 + 0.5*a*t0^2 = -0.5*a*t0^2
-					const motioncalc_t rawDistanceToReverse = (motioncalc_t)-0.5 * seg->GetA() * msquare(t0) + distanceCarriedForwards;
-#if SAMC21 || RP2040							// avoid floating point multiplication
-					const motioncalc_t distanceToReverse = (newDirection) ? rawDistanceToReverse : -rawDistanceToReverse;
-#else
-					const motioncalc_t distanceToReverse = rawDistanceToReverse * multiplier;
-#endif
-					const int32_t stepsBeforeReverse = (int32_t)(distanceToReverse - (motioncalc_t)0.2);			// don't step and immediately step back again
-					// Note, stepsBeforeReverse may be negative at this point
-					if (stepsBeforeReverse <= netStepsInInitialDirection && netStepsInInitialDirection >= 0)
-					{
-						segmentStepLimit = reverseStartStep = netStepsInInitialDirection + 1;
-						state = DMState::cartDecelNoReverse;
-					}
-					else if (stepsBeforeReverse <= 0)
-					{
-						// Reversal happens immediately
-						newDirection = !newDirection;
-#if !(SAMC21 || RP2040)															// we've finished with 'multiplier' on these processors
-						multiplier = -multiplier;
-#endif
-						segmentStepLimit = reverseStartStep = 1 - netStepsInInitialDirection;
-						state = DMState::cartAccel;
-					}
-					else
-					{
-						reverseStartStep = stepsBeforeReverse + 1;
-						segmentStepLimit = 2 * reverseStartStep - netStepsInInitialDirection - 1;
-						state = DMState::cartDecelForwardsReversing;
-					}
-				}
-				else
-				{
-					// Reversal doesn't occur until after the end of this segment
-					segmentStepLimit = reverseStartStep = netStepsInInitialDirection + 1;
-					state = DMState::cartDecelNoReverse;
-				}
-			}
-			rawP = (motioncalc_t)2.0/seg->GetA();
-			q = msquare(t0) - rawP * distanceCarriedForwards;
-#if 0
-			if (std::isinf(q))
-			{
-				debugPrintf("t0=%.1f mult=%.1f dcf=%.3e a=%.4e\n", (double)t0, (double)multiplier, (double)distanceCarriedForwards, (double)seg->GetA());
-			}
-#endif
-		}
-
-#if SAMC21 || RP2040							// avoid floating point multiplication
-		p = (newDirection) ? rawP : -rawP;
-#else
-		p = rawP * multiplier;
-#endif
+		const bool segIsLinear = seg->NormaliseAndCheckLinear(distanceCarriedForwards, t0);
+		SegAnalysis an;
+		AnalyseSegment(segIsLinear, t0, netStepsThisSegment, seg->GetLength(), seg->GetA(), seg->GetDuration(), distanceCarriedForwards, an);
+		const bool newDirection = an.direction;
+		segmentStepLimit = an.stepLimit;
+		reverseStartStep = an.reverseStartStep;
+		state = an.state;
+		q = an.q;
+		p = an.p;
 
 		nextStep = 1;
 		if (nextStep < segmentStepLimit)

--- a/src/Movement/DriveMovement.h
+++ b/src/Movement/DriveMovement.h
@@ -106,6 +106,14 @@ private:
 
 	static int32_t maxStepsLate;
 
+#if SHADOW_CACHE_DIAGNOSTICS
+	// Shadow slot diagnostics, reported and reset by M122 (Move is a friend); aggregated over all drives, with the same benign race as maxStepsLate
+	static uint32_t shadowCacheHits;					// the number of segments (stepping or zero-step) consumed from a prepared slot instead of doing the float maths
+	static uint32_t shadowCacheMisses;					// the number of segments that had to do the coefficient maths in the ISR (no slot prepared, or it was invalidated)
+	static uint32_t maxCacheSkip;						// the longest run of zero-step segments released via a prepared slot in one go
+	static uint32_t maxIsrSkip;							// the longest run of zero-step segments one NewSegment call had to skip the slow way, one at a time
+#endif
+
 	// Parameters common to Cartesian, delta and extruder moves
 
 #if !SINGLE_DRIVER

--- a/src/Movement/DriveMovement.h
+++ b/src/Movement/DriveMovement.h
@@ -74,6 +74,33 @@ private:
 	MoveSegment *NewSegment(uint32_t now) noexcept SPEED_CRITICAL;
 	bool ScheduleFirstSegment() noexcept;
 
+#if USE_SHADOW_SEGMENTS
+	// Movement parameters of one upcoming stepping segment, prepared in advance so that the segment-boundary invocations
+	// of the step ISR need not do the coefficient float maths. A slot spans an optional run of contiguous zero-step
+	// segments ("slivers") followed by one stepping segment, so that the ISR can release a whole sliver run without any
+	// per-segment float maths either. seg doubles as the validity flag.
+	struct ShadowSlot
+	{
+		const MoveSegment *volatile seg;				// the stepping segment this slot is for, or nullptr if the slot is free
+		const MoveSegment *chainHead;					// the first segment the slot spans: the first sliver, or seg itself if numSlivers == 0
+		uint8_t numSlivers;								// the number of contiguous zero-step segments before seg that this slot spans
+		DMState state;									// the initial DM state for seg
+		bool direction;									// the initial direction for seg
+		int32_t netSteps;								// netStepsThisSegment for seg
+		int32_t stepLimit;								// segmentStepLimit for seg
+		int32_t reverseStartStep;						// reverseStartStep for seg
+		motioncalc_t dcfAtSeg;							// distanceCarriedForwards at the start of seg, i.e. after the slivers
+		motioncalc_t dcfAfterSeg;						// distanceCarriedForwards after seg ends; anchors the preparation of the following slot
+		motioncalc_t t0, p, q;							// the movement parameters for seg (see the members of the same names below)
+	};
+
+	static constexpr unsigned int NumShadowSlots = 3;
+
+	bool PrepareShadowChunk() noexcept;					// prepare one more slot if possible, returning true if a slot was filled; called from Move::Spin (MAIN task) only; deliberately in flash
+	void InvalidateShadowsFrom(uint32_t startTime) noexcept;	// invalidate all slots that segments added from startTime onwards may modify; caller must shut out the step interrupt
+	void FlushShadows() noexcept;						// drop all prepared slots; caller must be the step ISR or have it shut out
+#endif
+
 	void ReleaseSegments() noexcept;					// release the list of segments and set it to nullptr
 	bool LogStepError(uint8_t type, float info, const MoveSegment *seg) noexcept;	// report a step error
 
@@ -103,6 +130,14 @@ private:
 	int32_t segmentStepLimit;							// the first step number of the next phase, or the reverse start step if smaller
 	int32_t reverseStartStep;							// the step number for which we need to reverse direction due to pressure advance or delta movement
 	motioncalc_t q, t0, p;								// the movement parameters of the current segment, if there is one
+#if USE_SHADOW_SEGMENTS
+	// The ring of prepared upcoming segments. The step ISR is the sole consumer, Move::Spin (MAIN task) the sole producer;
+	// AddLinearSegments invalidates slots that an incoming move may modify, and anything that releases segments outside the
+	// prepared order flushes all slots, so the boundary falls back to the normal path and correctness never depends on the preparation.
+	ShadowSlot shadowSlots[NumShadowSlots];
+	uint8_t shadowHead;									// the index of the slot the step ISR will consume next
+	volatile uint32_t shadowGen;						// bumped whenever the ISR releases a segment or consumes/flushes slots; guards the producer's snapshots
+#endif
 #if SUPPORT_CLOSED_LOOP
 	motioncalc_t u;										// the initial speed of this segment
 #endif
@@ -164,6 +199,21 @@ inline int32_t DriveMovement::GetAndClearMaxStepsLate() noexcept
 	maxStepsLate = 0;
 	return ret;
 }
+
+#if USE_SHADOW_SEGMENTS
+
+// Drop all prepared slots. Called from the step ISR, or with the step interrupt shut out, when the segment list no
+// longer matches what the preparation saw or the segments are about to be released.
+inline void DriveMovement::FlushShadows() noexcept
+{
+	for (unsigned int k = 0; k < NumShadowSlots; ++k)
+	{
+		shadowSlots[k].seg = nullptr;
+	}
+	++shadowGen;
+}
+
+#endif
 
 // Return the number of net steps already taken for the current segment in the forwards direction.
 // Caller must disable interrupts before calling this

--- a/src/Movement/Move.cpp
+++ b/src/Movement/Move.cpp
@@ -266,6 +266,19 @@ void Move::Spin(bool powered) noexcept
 void Move::Spin() noexcept
 #endif
 {
+#if USE_SHADOW_SEGMENTS
+	// Prepare upcoming segment parameters for the step ISR; cheap when there is nothing to prepare.
+	// This must remain the only caller of PrepareShadowChunk (single producer).
+# if SINGLE_DRIVER
+	while (dms[0].PrepareShadowChunk()) { }
+# else
+	for (size_t drive = 0; drive < NumDrivers; ++drive)
+	{
+		while (dms[drive].PrepareShadowChunk()) { }
+	}
+# endif
+#endif
+
 # if SUPPORT_BRAKE_PWM
 	const float currentVinVoltage = Platform::GetCurrentVinVoltage();
 # endif
@@ -1044,6 +1057,10 @@ void Move::AddLinearSegments(size_t drive, uint32_t startTime, const PrepParams&
 		const uint32_t oldFlags = IrqSave();
 #else
 		const uint32_t oldPrio = ChangeBasePriority(NvicPriorityStep);					// shut out the step interrupt
+#endif
+#if USE_SHADOW_SEGMENTS
+		// Invalidate any prepared slots for segments that the segments we are about to add may modify; those boundaries fall back to the normal path
+		dm.InvalidateShadowsFrom(startTime);
 #endif
 
 		// Start the search at the cached insertion hint if it is still valid, i.e. it is a segment still in the list that

--- a/src/Movement/Move.cpp
+++ b/src/Movement/Move.cpp
@@ -511,6 +511,16 @@ void Move::AppendDiagnostics(const StringRef& reply) noexcept
 	reply.lcatf("Moves scheduled %" PRIu32 ", hiccups %u (%.2f/%.2fms), segs %u, step errors %u (types 0x%x), maxLate %" PRIi32 " maxPrep %" PRIu32,
 					scheduledMoves, numHiccups, (double)ownDelayToReport, (double)totalDelayToReport, MoveSegment::NumCreated(),
 					numStepErrors, stepErrorTypesLogged.GetRaw(), DriveMovement::GetAndClearMaxStepsLate(), maxPrepareTime);
+#if SHADOW_CACHE_DIAGNOSTICS
+	{
+		const uint32_t hits = DriveMovement::shadowCacheHits;
+		const uint32_t total = hits + DriveMovement::shadowCacheMisses;
+		reply.catf(", cacheHit %.1f%% (%" PRIu32 "/%" PRIu32 "), maxSkip %" PRIu32 ", maxCacheSkip %" PRIu32,
+						(double)((total == 0) ? 0.0f : (float)hits * 100.0f/(float)total), hits, total,
+						DriveMovement::maxIsrSkip, DriveMovement::maxCacheSkip);
+		DriveMovement::shadowCacheHits = DriveMovement::shadowCacheMisses = DriveMovement::maxIsrSkip = DriveMovement::maxCacheSkip = 0;
+	}
+#endif
 	numHiccups = 0;
 	maxPrepareTime = 0;
 	numStepErrors = 0;

--- a/src/Movement/MoveSegment.h
+++ b/src/Movement/MoveSegment.h
@@ -338,4 +338,8 @@ inline void MoveSegment::Merge(motioncalc_t p_distance, motioncalc_t p_a, Moveme
 # endif
 #endif
 
+// Change the 0 to 1 to compile in the shadow slot cache statistics (cacheHit/maxSkip/maxCacheSkip in M122).
+// Collecting them costs a few cycles at each segment boundary and about 50 bytes of RAM code.
+#define SHADOW_CACHE_DIAGNOSTICS	(USE_SHADOW_SEGMENTS && 0)
+
 #endif /* SRC_MOVEMENT_MOVESEGMENT_H_ */

--- a/src/Movement/MoveSegment.h
+++ b/src/Movement/MoveSegment.h
@@ -213,8 +213,9 @@ inline bool IsPositive(motioncalc_t f) noexcept
 }
 
 // Core of NormaliseAndCheckLinear below: decide whether a segment is to be treated as constant speed and compute the
-// corresponding t0, without modifying anything, so that code working on a copy of the segment fields can compute
-// bit-identical results from a single copy of this code.
+// corresponding t0, without modifying anything. Written once, so that NormaliseAndCheckLinear and
+// DriveMovement::PrepareShadowChunk (which works on a copy of the segment fields, because the segment may still be
+// modified before it executes) compute bit-identical results from a single copy of this code.
 // Returns 0 if the segment has usable acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero;
 //         1 if it is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero;
 //         2 if it is to be treated as constant speed (t0 as for 1) because its tiny acceleration would cause calculation problems.
@@ -322,5 +323,19 @@ inline void MoveSegment::Merge(motioncalc_t p_distance, motioncalc_t p_a, Moveme
 	a += p_a;
 	nextAndFlags |= (p_flags.all & MovementFlags::FlagsMask);
 }
+
+// Prepare the movement parameters of upcoming segments outside the step ISR (see DriveMovement::PrepareShadowChunk).
+// Two classes of step ISR invocation are otherwise unbounded and can exceed MaxStepInterruptTime, provoking a hiccup:
+// a segment boundary whose first step is already due when it is reached (almost a whole step carried forward), and a run
+// of zero-step segments (produced in numbers by input shaping), each costing the full coefficient float maths just to be
+// skipped. This matters on boards that do the motion calculations in soft float, so it is enabled on the SAMC21 (no FPU);
+// other boards compile exactly the code they did before. May be predefined (e.g. -DUSE_SHADOW_SEGMENTS=1) to override the default.
+#ifndef USE_SHADOW_SEGMENTS
+# if SAMC21 && !USE_DOUBLE_MOTIONCALC && !defined(__ECV__)
+#  define USE_SHADOW_SEGMENTS	(1)
+# else
+#  define USE_SHADOW_SEGMENTS	(0)
+# endif
+#endif
 
 #endif /* SRC_MOVEMENT_MOVESEGMENT_H_ */

--- a/src/Movement/MoveSegment.h
+++ b/src/Movement/MoveSegment.h
@@ -212,13 +212,15 @@ inline bool IsPositive(motioncalc_t f) noexcept
 #endif
 }
 
-// Normalise this segment by removing very small accelerations that cause problems, update t0, return true if it is linear
-// Called only from DriveMovement::NewSegment. Speed critical, hence inline and the rather unusual behaviour.
-// Returns:
-//  true if the segment is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero
-//  false if the segment has acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero
-inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedForwards, motioncalc_t& t0) noexcept
+// Core of NormaliseAndCheckLinear below: decide whether a segment is to be treated as constant speed and compute the
+// corresponding t0, without modifying anything, so that code working on a copy of the segment fields can compute
+// bit-identical results from a single copy of this code.
+// Returns 0 if the segment has usable acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero;
+//         1 if it is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero;
+//         2 if it is to be treated as constant speed (t0 as for 1) because its tiny acceleration would cause calculation problems.
+static inline unsigned int CheckLinearCore(motioncalc_t a, uint32_t duration, motioncalc_t distance, motioncalc_t distanceCarriedForwards, motioncalc_t& t0) noexcept
 {
+	unsigned int ret = 1;
 	if (IsNonZero(a))
 	{
 		// The move has acceleration or deceleration, but it may be small enough to cause problems with the calculations.
@@ -239,16 +241,29 @@ inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedFor
 		if (likely(fabsm(provisionalT0) <= 4 * (motioncalc_t)16777216.0))
 		{
 			t0 = provisionalT0;
-			return false;
+			return 0;
 		}
-
-		// The acceleration/deceleration is small enough to cause calculation problems, so change it to a linear move
-		a = (motioncalc_t)0.0;
+		ret = 2;												// the acceleration is small enough to cause calculation problems, so treat this as a linear move
 	}
 
 	// The move is constant speed
 	t0 = -distanceCarriedForwards * (motioncalc_t)duration/distance;
-	return true;
+	return ret;
+}
+
+// Normalise this segment by removing very small accelerations that cause problems, update t0, return true if it is linear
+// Called only from DriveMovement::NewSegment. Speed critical, hence inline and the rather unusual behaviour.
+// Returns:
+//  true if the segment is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero
+//  false if the segment has acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero
+inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedForwards, motioncalc_t& t0) noexcept
+{
+	const unsigned int ret = CheckLinearCore(a, duration, distance, distanceCarriedForwards, t0);
+	if (ret == 2)
+	{
+		a = (motioncalc_t)0.0;									// remove the tiny acceleration, so that the rest of the segment processing treats it as linear
+	}
+	return ret != 0;
 }
 
 // Release a MoveSegment


### PR DESCRIPTION
## Problem

On boards without a hardware FPU (currently the SAMC21 boards) the step ISR is dominated by soft-float arithmetic. At every segment boundary `NewSegment` runs the full coefficient setup (`NormaliseAndCheckLinear`, two soft-float divisions and the reversal analysis) inside the ISR. Input shaping and pressure advance produce large numbers of short and zero-step segments, and at high extruder microstepping a boundary invocation can then exceed `MaxStepInterruptTime` and provoke hiccups, which insert movement delay and show up as an extrusion wave and audible artefacts on long fast walls.

## What this PR does

It moves the segment-boundary float maths out of the step ISR and into the Move task:

- `DriveMovement` gets a ring of three shadow slots. `Move::Spin` (MAIN task, sole producer) prepares the movement parameters (t0/p/q, step limits, initial state and direction) of upcoming stepping segments into free slots, together with any preceding run of contiguous zero-step segments ('slivers'). Each source segment is copied under a brief interrupt-disabled window, and a slot is committed only if a generation counter shows that nothing changed while it was being computed.
- When the step ISR (sole consumer) reaches a segment boundary covered by a valid slot, it applies the prepared parameters directly and releases a preceding sliver run without any per-segment float maths.
- Correctness never depends on the preparation: `Move::AddLinearSegments` invalidates slots that the segments of an incoming move may modify, any release outside the prepared order flushes all slots, and the boundary then falls back to the unchanged normal path.
- The preparation runs the same single copy of the segment analysis code (`AnalyseSegment`/`CheckLinearCore`) that the normal path uses, on a copy of the segment fields, so prepared and normal-path results are bit-identical.

`USE_SHADOW_SEGMENTS` (MoveSegment.h) enables the mechanism on the SAMC21 only; the default is overridable. `SHADOW_CACHE_DIAGNOSTICS` (default off) optionally adds cacheHit/maxSkip/maxCacheSkip statistics to the M122 Move diagnostics.

## Structure and merge path

This PR is stacked on #34:

- #34 contains all changes to **existing** code: the extraction of the segment analysis out of `NewSegment` and `NormaliseAndCheckLinear` - a pure refactor with no functional change, reviewable and mergeable on its own.
- The two commits on top (this PR proper) contain only **new** code: the shadow slot mechanism and the optional M122 statistics. With `USE_SHADOW_SEGMENTS` disabled, every other board compiles exactly the code it compiles with #34 alone.

Until #34 is merged, its commit also appears at the bottom of this PR's commit list (it is the same commit; a PR cannot use a fork branch as its base). Once #34 is in, this PR reduces to the two feature commits.

It now also requires #28, for the reason given below, so the intended order is #34 and #28 first, then this PR.

## Testing

TOOL1LC v1.1 at x64 extruder microstepping (3116 steps/mm) with input shaping and pressure advance, head-to-head against 3.6.3 on the same g-code: a reference print that consistently produced 117 hiccups and audible artefacts on 3.6.3 completed with 0 hiccups and clean walls with this mechanism enabled. The branch has since been restructured (diff minimised, split into #34 plus this PR, intent comments restored) with no functional change - the rebuilt tip builds bit-identically apart from the build timestamp. The current tip merged with #28 builds clean for TOOL1LC with the feature enabled, with the diagnostics both off and on; with `USE_SHADOW_SEGMENTS` disabled it still compiles on its own.

## Relation to #28

This PR should be merged after #28. The sliver release loop invalidates `segHint`, the insertion hint that #28 adds to `DriveMovement`, when it releases the segment that hint points to; without it `AddLinearSegments` could resume its search from a released segment. It deliberately leaves `segmentsTail` alone, because a valid slot guarantees a stepping segment after the slivers, so the list cannot empty there.

That invalidation is unconditional, so with `USE_SHADOW_SEGMENTS` enabled this branch needs #28 in its base to compile; with the feature disabled it is unaffected, and the two branches still merge cleanly. An earlier revision guarded the line with a `SEGMENT_INSERTION_HINT` macro defined by #28, so that the landing order did not matter; that macro has since been dropped from #28 and the guard with it.
