### PR TITLE
Movement: factor the segment analysis out of the step ISR paths

### DIFF
--- a/src/Movement/DriveMovement.cpp
+++ b/src/Movement/DriveMovement.cpp
@@ -75,6 +75,119 @@ bool DriveMovement::ScheduleFirstSegment() noexcept
 	return false;
 }
 
+// The result of analysing one segment against the distance carried forwards that it will start with
+struct SegAnalysis
+{
+	bool direction;										// the initial movement direction
+	DMState state;										// the initial DM state
+	int32_t stepLimit;									// the value for segmentStepLimit
+	int32_t reverseStartStep;							// the value for reverseStartStep
+	motioncalc_t p;										// the p coefficient, with the direction sign applied
+	motioncalc_t q;										// the q coefficient (0.0 for linear segments, to make the debug output consistent)
+};
+
+// Analyse one segment: calculate the p and q coefficients (t = t0 + sqrt(p*n + q) for accelerating or decelerating
+// segments), the step limits and the initial direction and state. Factored out of NewSegment, keeping exactly the
+// expressions it contained there, so that other code can compute bit-identical results from a copy of the segment fields.
+// segIsLinear and t0 are the results of MoveSegment::NormaliseAndCheckLinear on the same values.
+static inline void AnalyseSegment(bool segIsLinear, motioncalc_t t0, int32_t netSteps, motioncalc_t length, motioncalc_t a, uint32_t duration, motioncalc_t distanceCarriedForwards, SegAnalysis& out) noexcept
+{
+	bool newDirection;
+	int32_t multiplier;
+	motioncalc_t rawP;
+
+	if (segIsLinear)
+	{
+		// Segment is linear
+		rawP = (motioncalc_t)duration/length;					// as MoveSegment::CalcLinearRecipU
+		newDirection = !std::signbit(length);
+		multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
+		out.reverseStartStep = out.stepLimit = 1 + netSteps * multiplier;
+		out.q = (motioncalc_t)0.0;								// to make the debug output consistent
+		out.state = DMState::cartLinear;
+	}
+	else
+	{
+		// Segment has acceleration or deceleration
+		// n = distanceCarriedForwards + u * t + 0.5 * a * t^2
+		// Therefore 0.5 * t^2 + u * t/a + (distanceCarriedForwards - n)/a = 0
+		// Therefore t = -u/a +/- sqrt((u/a)^2 - 2 * (distanceCarriedForwards - n)/a)
+		// Calculate the t0, p and q coefficients for an accelerating or decelerating move such that t = t0 + sqrt(p*n + q) and set up the initial direction
+		newDirection = !std::signbit(a);			// assume accelerating motion
+		multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
+		if (!IsPositive(t0))								// use IsPositive here, on Cortex-M0+ it's faster than a floating point compare
+		{
+			// The direction reversal is in the past so the initial direction is the direction of the acceleration
+			out.stepLimit = out.reverseStartStep = 1 + netSteps * multiplier;
+			out.state = DMState::cartAccel;
+		}
+		else
+		{
+			// The initial direction is opposite to the acceleration
+			newDirection = !newDirection;
+			multiplier = -multiplier;
+			const int32_t netStepsInInitialDirection = netSteps * multiplier;
+
+			if (t0 < (motioncalc_t)duration)
+			{
+				// Reversal is potentially in this segment, but it may be before the first step, or may be beyond the last step we are going to take
+				// It can also happen that the target end speed is zero but due to FP rounding error, distanceToReverse was just below netStepsInInitialDirection and got rounded down
+				// Note, t0 = -u/a therefore u = a*t0 therefore u*t0^2 + 0.5*a*t0^2 = -a*t0^2 + 0.5*a*t0^2 = -0.5*a*t0^2
+				const motioncalc_t rawDistanceToReverse = (motioncalc_t)-0.5 * a * msquare(t0) + distanceCarriedForwards;
+#if SAMC21 || RP2040							// avoid floating point multiplication
+				const motioncalc_t distanceToReverse = (newDirection) ? rawDistanceToReverse : -rawDistanceToReverse;
+#else
+				const motioncalc_t distanceToReverse = rawDistanceToReverse * multiplier;
+#endif
+				const int32_t stepsBeforeReverse = (int32_t)(distanceToReverse - (motioncalc_t)0.2);			// don't step and immediately step back again
+				// Note, stepsBeforeReverse may be negative at this point
+				if (stepsBeforeReverse <= netStepsInInitialDirection && netStepsInInitialDirection >= 0)
+				{
+					out.stepLimit = out.reverseStartStep = netStepsInInitialDirection + 1;
+					out.state = DMState::cartDecelNoReverse;
+				}
+				else if (stepsBeforeReverse <= 0)
+				{
+					// Reversal happens immediately
+					newDirection = !newDirection;
+#if !(SAMC21 || RP2040)															// we've finished with 'multiplier' on these processors
+					multiplier = -multiplier;
+#endif
+					out.stepLimit = out.reverseStartStep = 1 - netStepsInInitialDirection;
+					out.state = DMState::cartAccel;
+				}
+				else
+				{
+					out.reverseStartStep = stepsBeforeReverse + 1;
+					out.stepLimit = 2 * out.reverseStartStep - netStepsInInitialDirection - 1;
+					out.state = DMState::cartDecelForwardsReversing;
+				}
+			}
+			else
+			{
+				// Reversal doesn't occur until after the end of this segment
+				out.stepLimit = out.reverseStartStep = netStepsInInitialDirection + 1;
+				out.state = DMState::cartDecelNoReverse;
+			}
+		}
+		rawP = (motioncalc_t)2.0/a;
+		out.q = msquare(t0) - rawP * distanceCarriedForwards;
+#if 0
+		if (std::isinf(out.q))
+		{
+			debugPrintf("t0=%.1f mult=%.1f dcf=%.3e a=%.4e\n", (double)t0, (double)multiplier, (double)distanceCarriedForwards, (double)a);
+		}
+#endif
+	}
+
+#if SAMC21 || RP2040							// avoid floating point multiplication
+	out.p = (newDirection) ? rawP : -rawP;
+#else
+	out.p = rawP * multiplier;
+#endif
+	out.direction = newDirection;
+}
+
 // This is called when we need to examine the segment list and prepare the head segment (if there is one) for execution.
 // If there is no segment to execute, set our state to 'idle' and return nullptr.
 // If there is a segment to execute but it isn't due to start for a while, set our state to 'starting', set nextStepTime to when the move is due to start or shortly before,
@@ -123,99 +236,15 @@ MoveSegment *DriveMovement::NewSegment(uint32_t now) noexcept
 		}
 #endif
 
-		bool newDirection;
-		int32_t multiplier;
-		motioncalc_t rawP;
-
-		if (seg->NormaliseAndCheckLinear(distanceCarriedForwards, t0))
-		{
-			// Segment is linear
-			rawP = seg->CalcLinearRecipU();
-			newDirection = !std::signbit(seg->GetLength());
-			multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
-			reverseStartStep = segmentStepLimit = 1 + netStepsThisSegment * multiplier;
-			q = (motioncalc_t)0.0;								// to make the debug output consistent
-			state = DMState::cartLinear;
-		}
-		else
-		{
-			// Segment has acceleration or deceleration
-			// n = distanceCarriedForwards + u * t + 0.5 * a * t^2
-			// Therefore 0.5 * t^2 + u * t/a + (distanceCarriedForwards - n)/a = 0
-			// Therefore t = -u/a +/- sqrt((u/a)^2 - 2 * (distanceCarriedForwards - n)/a)
-			// Calculate the t0, p and q coefficients for an accelerating or decelerating move such that t = t0 + sqrt(p*n + q) and set up the initial direction
-			newDirection = !std::signbit(seg->GetA());			// assume accelerating motion
-			multiplier = 2 * (int32_t)newDirection - 1;			// +1 or -1
-			if (!IsPositive(t0))								// use IsPositive here, on Cortex-M0+ it's faster than a floating point compare
-			{
-				// The direction reversal is in the past so the initial direction is the direction of the acceleration
-				segmentStepLimit = reverseStartStep = 1 + netStepsThisSegment * multiplier;
-				state = DMState::cartAccel;
-			}
-			else
-			{
-				// The initial direction is opposite to the acceleration
-				newDirection = !newDirection;
-				multiplier = -multiplier;
-				const int32_t netStepsInInitialDirection = netStepsThisSegment * multiplier;
-
-				if (t0 < (motioncalc_t)seg->GetDuration())
-				{
-					// Reversal is potentially in this segment, but it may be before the first step, or may be beyond the last step we are going to take
-					// It can also happen that the target end speed is zero but due to FP rounding error, distanceToReverse was just below netStepsInInitialDirection and got rounded down
-					// Note, t0 = -u/a therefore u = a*t0 therefore u*t0^2 + 0.5*a*t0^2 = -a*t0^2 + 0.5*a*t0^2 = -0.5*a*t0^2
-					const motioncalc_t rawDistanceToReverse = (motioncalc_t)-0.5 * seg->GetA() * msquare(t0) + distanceCarriedForwards;
-#if SAMC21 || RP2040							// avoid floating point multiplication
-					const motioncalc_t distanceToReverse = (newDirection) ? rawDistanceToReverse : -rawDistanceToReverse;
-#else
-					const motioncalc_t distanceToReverse = rawDistanceToReverse * multiplier;
-#endif
-					const int32_t stepsBeforeReverse = (int32_t)(distanceToReverse - (motioncalc_t)0.2);			// don't step and immediately step back again
-					// Note, stepsBeforeReverse may be negative at this point
-					if (stepsBeforeReverse <= netStepsInInitialDirection && netStepsInInitialDirection >= 0)
-					{
-						segmentStepLimit = reverseStartStep = netStepsInInitialDirection + 1;
-						state = DMState::cartDecelNoReverse;
-					}
-					else if (stepsBeforeReverse <= 0)
-					{
-						// Reversal happens immediately
-						newDirection = !newDirection;
-#if !(SAMC21 || RP2040)															// we've finished with 'multiplier' on these processors
-						multiplier = -multiplier;
-#endif
-						segmentStepLimit = reverseStartStep = 1 - netStepsInInitialDirection;
-						state = DMState::cartAccel;
-					}
-					else
-					{
-						reverseStartStep = stepsBeforeReverse + 1;
-						segmentStepLimit = 2 * reverseStartStep - netStepsInInitialDirection - 1;
-						state = DMState::cartDecelForwardsReversing;
-					}
-				}
-				else
-				{
-					// Reversal doesn't occur until after the end of this segment
-					segmentStepLimit = reverseStartStep = netStepsInInitialDirection + 1;
-					state = DMState::cartDecelNoReverse;
-				}
-			}
-			rawP = (motioncalc_t)2.0/seg->GetA();
-			q = msquare(t0) - rawP * distanceCarriedForwards;
-#if 0
-			if (std::isinf(q))
-			{
-				debugPrintf("t0=%.1f mult=%.1f dcf=%.3e a=%.4e\n", (double)t0, (double)multiplier, (double)distanceCarriedForwards, (double)seg->GetA());
-			}
-#endif
-		}
-
-#if SAMC21 || RP2040							// avoid floating point multiplication
-		p = (newDirection) ? rawP : -rawP;
-#else
-		p = rawP * multiplier;
-#endif
+		const bool segIsLinear = seg->NormaliseAndCheckLinear(distanceCarriedForwards, t0);
+		SegAnalysis an;
+		AnalyseSegment(segIsLinear, t0, netStepsThisSegment, seg->GetLength(), seg->GetA(), seg->GetDuration(), distanceCarriedForwards, an);
+		const bool newDirection = an.direction;
+		segmentStepLimit = an.stepLimit;
+		reverseStartStep = an.reverseStartStep;
+		state = an.state;
+		q = an.q;
+		p = an.p;
 
 		nextStep = 1;
 		if (nextStep < segmentStepLimit)

--- a/src/Movement/MoveSegment.h
+++ b/src/Movement/MoveSegment.h
@@ -212,13 +212,15 @@ inline bool IsPositive(motioncalc_t f) noexcept
 #endif
 }
 
-// Normalise this segment by removing very small accelerations that cause problems, update t0, return true if it is linear
-// Called only from DriveMovement::NewSegment. Speed critical, hence inline and the rather unusual behaviour.
-// Returns:
-//  true if the segment is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero
-//  false if the segment has acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero
-inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedForwards, motioncalc_t& t0) noexcept
+// Core of NormaliseAndCheckLinear below: decide whether a segment is to be treated as constant speed and compute the
+// corresponding t0, without modifying anything, so that code working on a copy of the segment fields can compute
+// bit-identical results from a single copy of this code.
+// Returns 0 if the segment has usable acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero;
+//         1 if it is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero;
+//         2 if it is to be treated as constant speed (t0 as for 1) because its tiny acceleration would cause calculation problems.
+static inline unsigned int CheckLinearCore(motioncalc_t a, uint32_t duration, motioncalc_t distance, motioncalc_t distanceCarriedForwards, motioncalc_t& t0) noexcept
 {
+	unsigned int ret = 1;
 	if (IsNonZero(a))
 	{
 		// The move has acceleration or deceleration, but it may be small enough to cause problems with the calculations.
@@ -239,16 +241,29 @@ inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedFor
 		if (likely(fabsm(provisionalT0) <= 4 * (motioncalc_t)16777216.0))
 		{
 			t0 = provisionalT0;
-			return false;
+			return 0;
 		}
-
-		// The acceleration/deceleration is small enough to cause calculation problems, so change it to a linear move
-		a = (motioncalc_t)0.0;
+		ret = 2;												// the acceleration is small enough to cause calculation problems, so treat this as a linear move
 	}
 
 	// The move is constant speed
 	t0 = -distanceCarriedForwards * (motioncalc_t)duration/distance;
-	return true;
+	return ret;
+}
+
+// Normalise this segment by removing very small accelerations that cause problems, update t0, return true if it is linear
+// Called only from DriveMovement::NewSegment. Speed critical, hence inline and the rather unusual behaviour.
+// Returns:
+//  true if the segment is constant speed, with t0 = time from start of segment at which the distance would be/will be/would have been zero
+//  false if the segment has acceleration or deceleration, with t0 = time from start of segment at which the speed would have been/will be/would be zero
+inline bool MoveSegment::NormaliseAndCheckLinear(motioncalc_t distanceCarriedForwards, motioncalc_t& t0) noexcept
+{
+	const unsigned int ret = CheckLinearCore(a, duration, distance, distanceCarriedForwards, t0);
+	if (ret == 2)
+	{
+		a = (motioncalc_t)0.0;									// remove the tiny acceleration, so that the rest of the segment processing treats it as linear
+	}
+	return ret != 0;
 }
 
 // Release a MoveSegment


### PR DESCRIPTION
This factors the segment analysis out of the two step-ISR code paths, with no functional change:

- the decision part of `MoveSegment::NormaliseAndCheckLinear` - whether a segment is to be treated as constant speed, and the corresponding t0 - becomes `CheckLinearCore`, which modifies nothing; `NormaliseAndCheckLinear` wraps it and still removes a problematically small acceleration from the segment;
- the analysis part of `DriveMovement::NewSegment` - the p and q coefficients, the step limits and the initial direction and state - becomes `AnalyseSegment`, returning its results in a small `SegAnalysis` struct.

Both contain exactly the expressions they contained in their original places, so the analysis computes exactly the values it did before on every board.

The purpose is to let code that works on a copy of the segment fields compute movement parameters bit-identical to those the step ISR computes, from a single copy of the analysis code. #33 (prepare upcoming segments outside the step ISR) builds on this and will be rebased onto it; splitting the refactor out keeps that PR to the actual mechanism and makes this part reviewable on its own.

Codegen note: on the SAMC21 (TOOL1LC), GCC 13.2 emits `AnalyseSegment` as a single out-of-line copy in flash, called from `NewSegment`'s RAM copy; the only object file that changes relative to stock is DriveMovement.o. The same code layout ran throughout the hardware testing of the shadow-segments work.