### PR TITLE
[bug] Fix FreeRTOS assertion when the tick ISR detects a stuck spin loop

### DIFF
--- a/src/Heating/Heat.cpp
+++ b/src/Heating/Heat.cpp
@@ -613,6 +613,21 @@ void Heat::SwitchOffAll() noexcept
 	}
 }
 
+// Turn all heaters off without taking the heaters lock. Safe to call from an ISR, so it must not call any FreeRTOS API that isn't
+// an ISR-safe variant. Taking heatersLock is not an option because ReadWriteLock uses vTaskSuspendAll/xTaskResumeAll, which assert
+// if called from an ISR. Called only from the tick ISR when we have decided to reset, so the small risk of racing with a task that
+// is adding or deleting a heater is acceptable - we are about to reset anyway, and leaving the heaters on is the greater danger.
+void Heat::SwitchOffAllLocalFromISR() noexcept
+{
+	for (Heater * const h : heaters)
+	{
+		if (h != nullptr)
+		{
+			h->SwitchOff();
+		}
+	}
+}
+
 void Heat::ResetFault(int heater) noexcept
 {
 	const auto h = FindHeater(heater);

--- a/src/Heating/Heat.h
+++ b/src/Heating/Heat.h
@@ -40,7 +40,8 @@ namespace Heat
 	GCodeResult SetFaultDetection(const CanMessageSetHeaterFaultDetectionParameters& msg, const StringRef& reply) noexcept;
 	GCodeResult SetHeaterMonitors(const CanMessageSetHeaterMonitors& msg, const StringRef& reply) noexcept;
 
-	void SwitchOffAll() noexcept;										// Turn all heaters off
+	void SwitchOffAll() noexcept;										// Turn all heaters off. Takes the heaters read lock, so NOT safe to call from an ISR.
+	void SwitchOffAllLocalFromISR() noexcept;							// Turn all heaters off without taking any locks. Safe to call from an ISR.
 	void ResetFault(int heater) noexcept;								// Reset a heater fault - only call this if you know what you are doing
 
 	// Methods that relate to sensors

--- a/src/Platform/Tasks.cpp
+++ b/src/Platform/Tasks.cpp
@@ -1038,7 +1038,9 @@ static inline void CheckSpinLockAndResetIfStuck() noexcept
 
 	if (heatTaskStuck || syncedStuck || mainTaskStuck)		// if we stall, save diagnostic data and reset
 	{
-		Heat::SwitchOffAll();
+		// We are in the tick ISR, so we must not call Heat::SwitchOffAll here: it takes the heaters ReadWriteLock, which uses
+		// vTaskSuspendAll/xTaskResumeAll, and FreeRTOS asserts if those are called from an ISR.
+		Heat::SwitchOffAllLocalFromISR();
 #if SUPPORT_DRIVERS
 # if SUPPORT_TMC51xx
 		IoPort::WriteDigital(GlobalTmc51xxEnablePin, true);


### PR DESCRIPTION
CheckSpinLockAndResetIfStuck runs in the tick ISR and called Heat::SwitchOffAll, which takes the heaters ReadWriteLock. ReadWriteLock uses vTaskSuspendAll/ xTaskResumeAll, and xTaskResumeAll calls taskENTER_CRITICAL, so FreeRTOS asserted at port.c:488 on SAME5x (critical section entered from an ISR).

The assertion fired before Heat::SwitchOffAll had switched anything off, so the global driver enable pins and Move::DisableAllDrives were never reached and the board was left with heaters and drivers still on. It also replaced the reset reason with AssertionFailed instead of StuckInSpinLoop/HeaterWatchdog, and lost the PSP stack capture that would have shown which task had stalled.

Add Heat::SwitchOffAllLocalFromISR, matching the function of the same name in RepRapFirmware: the same loop without the ReadLocker. LocalHeater::SwitchOff calls SetHeater(0.0), which writes the heater ports directly, so the outputs go off without needing the heat task to run.